### PR TITLE
Us050a change response status completedbyphone

### DIFF
--- a/1
+++ b/1
@@ -1,1 +1,0 @@
-zsh: permission denied: /dev/null

--- a/1
+++ b/1
@@ -1,0 +1,1 @@
+zsh: permission denied: /dev/null

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.product</groupId>
       <artifactId>casesvc-api</artifactId>
-      <version>10.49.5-SNAPSHOT</version>
+      <version>10.49.6</version>
     </dependency>
 
     <dependency>
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.common</groupId>
       <artifactId>framework</artifactId>
-      <version>10.49.9-SNAPSHOT</version>
+      <version>10.49.9</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.product</groupId>
       <artifactId>casesvc-api</artifactId>
-      <version>10.49.4</version>
+      <version>10.49.5-SNAPSHOT</version>
     </dependency>
 
     <dependency>
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.common</groupId>
       <artifactId>framework</artifactId>
-      <version>10.49.8</version>
+      <version>10.49.9-SNAPSHOT</version>
     </dependency>
 
     <dependency>
@@ -185,12 +185,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.testng</groupId>
-      <artifactId>testng</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>
@@ -209,28 +203,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${surefire.version}</version>
-        <configuration>
-          <properties>
-            <property>
-              <name>junit</name>
-              <value>false</value>
-            </property>
-          </properties>
-          <threadCount>1</threadCount>
-        </configuration>
-        <!-- REQUIRED for unit tests to run -->
-        <dependencies>
-          <dependency>
-            <groupId>org.apache.maven.surefire</groupId>
-            <artifactId>surefire-junit47</artifactId>
-            <version>${surefire.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.apache.maven.surefire</groupId>
-            <artifactId>surefire-testng</artifactId>
-            <version>${surefire.version}</version>
-          </dependency>
-        </dependencies>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/domain/model/CaseGroup.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/domain/model/CaseGroup.java
@@ -56,7 +56,7 @@ public class CaseGroup implements Serializable {
   @Column(name = "sampleunittype")
   private String sampleUnitType;
 
-  @Enumerated(EnumType.STRING)
+    @Enumerated(EnumType.STRING)
   @Column(name = "status")
   private CaseGroupStatus status;
 

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/domain/repository/CaseGroupRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/domain/repository/CaseGroupRepository.java
@@ -18,4 +18,6 @@ public interface CaseGroupRepository extends JpaRepository<CaseGroup, Integer> {
      * @return the matching CaseGroup
      */
     CaseGroup findById(UUID id);
+
+    CaseGroup findCaseGroupByCollectionExerciseIdAndSampleUnitRef(UUID collectionExerciseId, String ruRef);
 }

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpoint.java
@@ -166,7 +166,7 @@ public final class CaseEndpoint implements CTPEndpoint {
     CaseGroup caseGroup = caseGroupService.findCaseGroupById(casegroupId);
     if (caseGroup == null) {
       throw new CTPException(CTPException.Fault.RESOURCE_NOT_FOUND,
-          String.format("CaseGroup not found for %s", casegroupId));
+          String.format("CaseGroup not found for casegroup id %s", casegroupId));
     }
 
     List<Case> casesList = caseService.findCasesByCaseGroupFK(caseGroup.getCaseGroupPK());

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpoint.java
@@ -40,8 +40,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import static uk.gov.ons.ctp.response.casesvc.endpoint.CaseGroupEndpoint.ERRORMSG_CASEGROUPNOTFOUND;
-
 /**
  * The REST endpoint controller for CaseSvc Cases
  */
@@ -168,7 +166,7 @@ public final class CaseEndpoint implements CTPEndpoint {
     CaseGroup caseGroup = caseGroupService.findCaseGroupById(casegroupId);
     if (caseGroup == null) {
       throw new CTPException(CTPException.Fault.RESOURCE_NOT_FOUND,
-          String.format("%s casegroup id %s", ERRORMSG_CASEGROUPNOTFOUND, casegroupId));
+          String.format("CaseGroup not found for %s", casegroupId));
     }
 
     List<Case> casesList = caseService.findCasesByCaseGroupFK(caseGroup.getCaseGroupPK());

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseGroupEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseGroupEndpoint.java
@@ -1,20 +1,22 @@
 package uk.gov.ons.ctp.response.casesvc.endpoint;
 
+import java.util.Map;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 import lombok.extern.slf4j.Slf4j;
 import ma.glasnost.orika.MapperFacade;
 import uk.gov.ons.ctp.common.endpoint.CTPEndpoint;
 import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.common.state.StateTransitionManager;
 import uk.gov.ons.ctp.response.casesvc.domain.model.CaseGroup;
 import uk.gov.ons.ctp.response.casesvc.representation.CaseGroupDTO;
+import uk.gov.ons.ctp.response.casesvc.representation.CaseGroupStatus;
+import uk.gov.ons.ctp.response.casesvc.representation.CategoryDTO;
 import uk.gov.ons.ctp.response.casesvc.service.CaseGroupService;
 
 /**
@@ -29,6 +31,9 @@ public final class CaseGroupEndpoint implements CTPEndpoint {
 
   @Autowired
   private CaseGroupService caseGroupService;
+
+  @Autowired
+  private StateTransitionManager<CaseGroupStatus, CategoryDTO.CategoryName> caseGroupStatusTransitionManager;
 
   @Qualifier("caseSvcBeanMapper")
   @Autowired
@@ -54,4 +59,59 @@ public final class CaseGroupEndpoint implements CTPEndpoint {
     return mapperFacade.map(caseGroupObj, CaseGroupDTO.class);
   }
 
+    /**
+     * the GET endpoint to find Case Group transitions by collectionExerciseId and ruRef
+     *
+     * @param collectionExerciseId UUID to find by
+     * @param ruRef String to find by
+     * @return the transitions available and the events needed to put it in this state for the caseGroupId
+     * @throws CTPException something went wrong
+     */
+    @RequestMapping(value = "/transitions/{collectionExerciseId}/{ruRef}", method = RequestMethod.GET)
+    public Map<CategoryDTO.CategoryName, CaseGroupStatus> findTransitionsByCollectionExerciseIdAndRuRef(
+        @PathVariable("collectionExerciseId") final UUID collectionExerciseId,
+        @PathVariable("ruRef") final String ruRef)
+        throws CTPException {
+          log.info("Entering findTransitionsByCollexIdAndRuRef with collectionExerciseId {}, ruRef {}",
+              collectionExerciseId, ruRef);
+
+          CaseGroup caseGroupObj = caseGroupService.findCaseGroupByCollectionExerciseIdAndRuRef(collectionExerciseId, ruRef);
+          if (caseGroupObj == null) {
+              throw new CTPException(CTPException.Fault.RESOURCE_NOT_FOUND, String.format("%s collectionExerciseId %s, ruRef %s",
+                      ERRORMSG_CASEGROUPNOTFOUND, collectionExerciseId, ruRef));
+          }
+          CaseGroupStatus caseGroupStatus = caseGroupObj.getStatus();
+
+          return caseGroupStatusTransitionManager.getAvailableTransitions(caseGroupStatus);
+    }
+
+  /**
+   * the PUT endpoint to change Case Group status from a given Case Group event
+   *
+   * @param collectionExerciseId UUID to find by
+   * @param ruRef String to find by
+   * @param caseGroupEvent Name of event
+   * @return 200 if all is ok, 400 for bad request
+   * @throws CTPException something went wrong
+   */
+  @RequestMapping(value = "/transitions/{collectionExerciseId}/{ruRef}", method = RequestMethod.PUT)
+  public ResponseEntity<?> changeCaseGroupStatus(
+      @PathVariable("collectionExerciseId") final UUID collectionExerciseId,
+      @PathVariable("ruRef") final String ruRef,
+      @RequestBody CaseGroupEvent caseGroupEvent)
+      throws CTPException {
+        log.info("Entering changeCaseGroupStatus with collectionExerciseId {}, ruRef {}, caseGroupEvent {}",
+            collectionExerciseId, ruRef, caseGroupEvent.getEvent());
+
+        CaseGroup caseGroupObj = caseGroupService.findCaseGroupByCollectionExerciseIdAndRuRef(collectionExerciseId, ruRef);
+        if (caseGroupObj == null) {
+          throw new CTPException(CTPException.Fault.RESOURCE_NOT_FOUND, String.format("%s collectionExerciseId %s, ruRef %s",
+              ERRORMSG_CASEGROUPNOTFOUND, collectionExerciseId, ruRef));
+        }
+
+        caseGroupService.transitionCaseGroupStatus(caseGroupObj, CategoryDTO.CategoryName.valueOf(caseGroupEvent.getEvent()),
+            caseGroupObj.getPartyId());
+
+        return ResponseEntity.ok().build();
+  }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseGroupEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseGroupEndpoint.java
@@ -1,23 +1,34 @@
 package uk.gov.ons.ctp.response.casesvc.endpoint;
 
-import java.util.Map;
-import java.util.UUID;
-
+import lombok.extern.slf4j.Slf4j;
+import ma.glasnost.orika.MapperFacade;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import lombok.extern.slf4j.Slf4j;
-import ma.glasnost.orika.MapperFacade;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
 import uk.gov.ons.ctp.common.endpoint.CTPEndpoint;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.common.state.StateTransitionManager;
+import uk.gov.ons.ctp.response.casesvc.domain.model.Case;
+import uk.gov.ons.ctp.response.casesvc.domain.model.CaseEvent;
 import uk.gov.ons.ctp.response.casesvc.domain.model.CaseGroup;
+import uk.gov.ons.ctp.response.casesvc.domain.model.Category;
 import uk.gov.ons.ctp.response.casesvc.representation.CaseGroupDTO;
 import uk.gov.ons.ctp.response.casesvc.representation.CaseGroupStatus;
 import uk.gov.ons.ctp.response.casesvc.representation.CategoryDTO;
 import uk.gov.ons.ctp.response.casesvc.service.CaseGroupService;
+import uk.gov.ons.ctp.response.casesvc.service.CaseService;
+import uk.gov.ons.ctp.response.casesvc.service.CategoryService;
+import uk.gov.ons.ctp.response.casesvc.utility.Constants;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 /**
  * The REST endpoint controller for CaseSvc CaseGroups
@@ -27,91 +38,116 @@ import uk.gov.ons.ctp.response.casesvc.service.CaseGroupService;
 @Slf4j
 public final class CaseGroupEndpoint implements CTPEndpoint {
 
-  public static final String ERRORMSG_CASEGROUPNOTFOUND = "CaseGroup not found for";
+    @Autowired
+    private CaseGroupService caseGroupService;
 
-  @Autowired
-  private CaseGroupService caseGroupService;
+    @Autowired
+    private CaseService caseService;
 
-  @Autowired
-  private StateTransitionManager<CaseGroupStatus, CategoryDTO.CategoryName> caseGroupStatusTransitionManager;
+    @Autowired
+    private StateTransitionManager<CaseGroupStatus, CategoryDTO.CategoryName> caseGroupStatusTransitionManager;
 
-  @Qualifier("caseSvcBeanMapper")
-  @Autowired
-  private MapperFacade mapperFacade;
+    @Autowired
+    private CategoryService categoryService;
 
- /**
-   * the GET endpoint to find CaseGroups by caseGroupId
-   *
-   * @param caseGroupId UUID to find by
-   * @return the casegroups found
-   * @throws CTPException something went wrong
-   */
-  @RequestMapping(value = "/{caseGroupId}", method = RequestMethod.GET)
-  public CaseGroupDTO findCaseGroupById(@PathVariable("caseGroupId") final UUID caseGroupId)  throws CTPException {
-    log.info("Entering findCaseGroupById with {}", caseGroupId);
+    @Qualifier("caseSvcBeanMapper")
+    @Autowired
+    private MapperFacade mapperFacade;
 
-    CaseGroup caseGroupObj = caseGroupService.findCaseGroupById(caseGroupId);
-    if (caseGroupObj == null) {
-        throw new CTPException(CTPException.Fault.RESOURCE_NOT_FOUND, String.format("%s casegroup id %s",
-                ERRORMSG_CASEGROUPNOTFOUND, caseGroupId));
+    /**
+     * the GET endpoint to find CaseGroups by caseGroupId
+     *
+     * @param caseGroupId UUID to find by
+     * @return the casegroups found
+     * @throws CTPException something went wrong
+     */
+    @RequestMapping(value = "/{caseGroupId}", method = RequestMethod.GET)
+    public CaseGroupDTO findCaseGroupById(@PathVariable("caseGroupId") final UUID caseGroupId) throws CTPException {
+        log.info("Entering findCaseGroupById with {}", caseGroupId);
+
+        CaseGroup caseGroupObj = caseGroupService.findCaseGroupById(caseGroupId);
+        if (caseGroupObj == null) {
+            throw new CTPException(CTPException.Fault.RESOURCE_NOT_FOUND,
+                    String.format("CaseGroup not found for casegroup id %s", caseGroupId));
+        }
+
+        return mapperFacade.map(caseGroupObj, CaseGroupDTO.class);
     }
-
-    return mapperFacade.map(caseGroupObj, CaseGroupDTO.class);
-  }
 
     /**
      * the GET endpoint to find Case Group transitions by collectionExerciseId and ruRef
      *
      * @param collectionExerciseId UUID to find by
-     * @param ruRef String to find by
+     * @param ruRef                String to find by
      * @return the transitions available and the events needed to put it in this state for the caseGroupId
      * @throws CTPException something went wrong
      */
     @RequestMapping(value = "/transitions/{collectionExerciseId}/{ruRef}", method = RequestMethod.GET)
     public Map<CategoryDTO.CategoryName, CaseGroupStatus> findTransitionsByCollectionExerciseIdAndRuRef(
-        @PathVariable("collectionExerciseId") final UUID collectionExerciseId,
-        @PathVariable("ruRef") final String ruRef)
-        throws CTPException {
-          log.info("Entering findTransitionsByCollexIdAndRuRef with collectionExerciseId {}, ruRef {}",
-              collectionExerciseId, ruRef);
-
-          CaseGroup caseGroupObj = caseGroupService.findCaseGroupByCollectionExerciseIdAndRuRef(collectionExerciseId, ruRef);
-          if (caseGroupObj == null) {
-              throw new CTPException(CTPException.Fault.RESOURCE_NOT_FOUND, String.format("%s collectionExerciseId %s, ruRef %s",
-                      ERRORMSG_CASEGROUPNOTFOUND, collectionExerciseId, ruRef));
-          }
-          CaseGroupStatus caseGroupStatus = caseGroupObj.getStatus();
-
-          return caseGroupStatusTransitionManager.getAvailableTransitions(caseGroupStatus);
-    }
-
-  /**
-   * the PUT endpoint to change Case Group status from a given Case Group event
-   *
-   * @param collectionExerciseId UUID to find by
-   * @param ruRef String to find by
-   * @param caseGroupEvent Name of event
-   * @return 200 if all is ok, 400 for bad request
-   * @throws CTPException something went wrong
-   */
-  @RequestMapping(value = "/transitions/{collectionExerciseId}/{ruRef}", method = RequestMethod.PUT)
-  public ResponseEntity<?> changeCaseGroupStatus(
-      @PathVariable("collectionExerciseId") final UUID collectionExerciseId,
-      @PathVariable("ruRef") final String ruRef,
-      @RequestBody CaseGroupEvent caseGroupEvent)
-      throws CTPException {
-        log.info("Entering changeCaseGroupStatus with collectionExerciseId {}, ruRef {}, caseGroupEvent {}",
-            collectionExerciseId, ruRef, caseGroupEvent.getEvent());
+            @PathVariable("collectionExerciseId") final UUID collectionExerciseId,
+            @PathVariable("ruRef") final String ruRef)
+            throws CTPException {
+        log.info("Entering findTransitionsByCollexIdAndRuRef with collectionExerciseId {}, ruRef {}",
+                collectionExerciseId, ruRef);
 
         CaseGroup caseGroupObj = caseGroupService.findCaseGroupByCollectionExerciseIdAndRuRef(collectionExerciseId, ruRef);
         if (caseGroupObj == null) {
-          throw new CTPException(CTPException.Fault.RESOURCE_NOT_FOUND, String.format("%s collectionExerciseId %s, ruRef %s",
-              ERRORMSG_CASEGROUPNOTFOUND, collectionExerciseId, ruRef));
+            throw new CTPException(CTPException.Fault.RESOURCE_NOT_FOUND,
+                    String.format("CaseGroup not found for collectionExerciseId %s, ruRef %s", collectionExerciseId, ruRef));
+        }
+        CaseGroupStatus caseGroupStatus = caseGroupObj.getStatus();
+
+        return caseGroupStatusTransitionManager.getAvailableTransitions(caseGroupStatus);
+    }
+
+    /**
+     * the PUT endpoint to change Case Group status from a given Case Group event
+     *
+     * @param collectionExerciseId UUID to find by
+     * @param ruRef                String to find by
+     * @param caseGroupEvent       Name of event
+     * @return 200 if all is ok, 400 for bad request
+     * @throws CTPException something went wrong
+     */
+    @RequestMapping(value = "/transitions/{collectionExerciseId}/{ruRef}", method = RequestMethod.PUT)
+    public ResponseEntity<?> changeCaseGroupStatus(
+            @PathVariable("collectionExerciseId") final UUID collectionExerciseId,
+            @PathVariable("ruRef") final String ruRef,
+            @RequestBody CaseGroupEvent caseGroupEvent)
+            throws CTPException {
+        String event = caseGroupEvent.getEvent();
+        log.info("Entering changeCaseGroupStatus with collectionExerciseId {}, ruRef {}, caseGroupEvent {}",
+                collectionExerciseId, ruRef, event);
+
+        if (!isValidEvent(event)) {
+            throw new CTPException(CTPException.Fault.BAD_REQUEST, String.format("Invalid event %s", event));
+        }
+        CategoryDTO.CategoryName eventCategory = CategoryDTO.CategoryName.valueOf(event);
+
+        CaseGroup caseGroupObj = caseGroupService.findCaseGroupByCollectionExerciseIdAndRuRef(collectionExerciseId, ruRef);
+        if (caseGroupObj == null) {
+            throw new CTPException(CTPException.Fault.RESOURCE_NOT_FOUND,
+                    String.format("CaseGroup not found for collectionExerciseId %s, ruRef %s", collectionExerciseId, ruRef));
+        }
+        List<Case> cases = caseService.findCasesByCaseGroupFK(caseGroupObj.getCaseGroupPK());
+        Category category = categoryService.findCategory(eventCategory);
+        for (Case c: cases) {
+            CaseEvent caseEvent = CaseEvent.builder()
+                    .caseFK(c.getCasePK())
+                    .category(eventCategory)
+                    .description(category.getShortDescription())
+                    .createdBy(Constants.USER)
+                    .build();
+            caseService.createCaseEvent(caseEvent, c);
         }
 
-        caseGroupService.transitionCaseGroupStatus(caseGroupObj, CategoryDTO.CategoryName.valueOf(caseGroupEvent.getEvent()),
-            caseGroupObj.getPartyId());
-
         return ResponseEntity.ok().build();
-  }
+    }
+
+    private boolean isValidEvent(String event) {
+        return Arrays.stream(CategoryDTO.CategoryName.values())
+                .map(Enum::name)
+                .filter(e -> e.equals(event))
+                .count() == 1;
+    }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseGroupEvent.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseGroupEvent.java
@@ -1,0 +1,9 @@
+package uk.gov.ons.ctp.response.casesvc.endpoint;
+
+import lombok.Data;
+
+@Data
+class CaseGroupEvent {
+
+  private String event;
+}

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/CaseGroupAuditService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/CaseGroupAuditService.java
@@ -1,14 +1,14 @@
 package uk.gov.ons.ctp.response.casesvc.service;
 
-import uk.gov.ons.ctp.response.casesvc.domain.model.Case;
-import uk.gov.ons.ctp.response.casesvc.domain.model.CaseEvent;
 import uk.gov.ons.ctp.response.casesvc.domain.model.CaseGroup;
+
+import java.util.UUID;
 
 public interface CaseGroupAuditService {
 
     /**
      * Updates the audit table for any alterations to the casegroupstatus for any casegroup
      */
-    void updateAuditTable(final CaseGroup caseGroup, final CaseEvent caseEvent, final Case caze) ;
+    void updateAuditTable(final CaseGroup caseGroup, final UUID partyId) ;
 
 }

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/CaseGroupService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/CaseGroupService.java
@@ -2,8 +2,10 @@ package uk.gov.ons.ctp.response.casesvc.service;
 
 import java.util.UUID;
 
+import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.common.service.CTPService;
 import uk.gov.ons.ctp.response.casesvc.domain.model.CaseGroup;
+import uk.gov.ons.ctp.response.casesvc.representation.CategoryDTO;
 
 /**
  * The CaseGroup Service interface defines all business behaviours for operations
@@ -27,12 +29,14 @@ public interface CaseGroupService extends CTPService {
    */
   CaseGroup findCaseGroupById(UUID id);
 
+  CaseGroup findCaseGroupByCollectionExerciseIdAndRuRef(final UUID collectionExerciseId, final String ruRef);
+
   /**
-   * Find CaseGroup by uprn
-   *
-   * @param uprn of the case groups to find
-   * @return List of CaseGroup entities or empty list if none
+   * For a given event, this will update and audit a transition
+   * @param caseGroup Case Group to transition
+   * @param categoryName The name of the event for a transition
+   * @param partyId party ID for auditing the transition
+   * @throws CTPException if transition is not executed
    */
-   // TODO BRES - replace with?
-   //List<CaseGroup> findCaseGroupsByUprn(Long uprn);
+  void transitionCaseGroupStatus(final CaseGroup caseGroup, final CategoryDTO.CategoryName categoryName, final UUID partyId) throws CTPException;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseGroupAuditServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseGroupAuditServiceImpl.java
@@ -4,12 +4,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.ons.ctp.common.time.DateTimeUtil;
-import uk.gov.ons.ctp.response.casesvc.domain.model.Case;
-import uk.gov.ons.ctp.response.casesvc.domain.model.CaseEvent;
 import uk.gov.ons.ctp.response.casesvc.domain.model.CaseGroup;
 import uk.gov.ons.ctp.response.casesvc.domain.model.CaseGroupStatusAudit;
 import uk.gov.ons.ctp.response.casesvc.service.CaseGroupAuditService;
 import uk.gov.ons.ctp.response.casesvc.domain.repository.CaseGroupStatusAuditRepository;
+
+import java.util.UUID;
 
 @Service
 @Slf4j
@@ -19,12 +19,12 @@ public class CaseGroupAuditServiceImpl implements CaseGroupAuditService {
     private CaseGroupStatusAuditRepository caseGroupStatusAuditRepository;
 
     @Override
-    public void updateAuditTable(final CaseGroup caseGroup, final CaseEvent caseEvent, final Case caze) {
+    public void updateAuditTable(final CaseGroup caseGroup, final UUID partyId) {
         CaseGroupStatusAudit auditEntity = new CaseGroupStatusAudit();
 
         auditEntity.setCaseGroupFK(caseGroup.getCaseGroupPK());
         auditEntity.setStatus(caseGroup.getStatus());
-        auditEntity.setPartyId(caze.getPartyId());
+        auditEntity.setPartyId(partyId);
         auditEntity.setCreatedDateTime(DateTimeUtil.nowUTC());
         log.info("Updating the caseGroupStatus to {}, for case group {}, due to actions by party, {}.",
                 auditEntity.getStatus(), auditEntity.getCaseGroupFK(), auditEntity.getPartyId());

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/state/CaseSvcStateTransitionManagerFactory.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/state/CaseSvcStateTransitionManagerFactory.java
@@ -1,5 +1,7 @@
 package uk.gov.ons.ctp.response.casesvc.state;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableTable;
 import org.springframework.stereotype.Component;
 import uk.gov.ons.ctp.common.state.BasicStateTransitionManager;
 import uk.gov.ons.ctp.common.state.StateTransitionManager;
@@ -9,7 +11,6 @@ import uk.gov.ons.ctp.response.casesvc.representation.CaseGroupStatus;
 import uk.gov.ons.ctp.response.casesvc.representation.CaseState;
 import uk.gov.ons.ctp.response.casesvc.representation.CategoryDTO;
 
-import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -23,63 +24,48 @@ public class CaseSvcStateTransitionManagerFactory implements StateTransitionMana
   public static final String CASE_ENTITY = "Case";
   public static final String CASE_GROUP = "CaseGroup";
 
-  private Map<String, StateTransitionManager<?, ?>> managers;
+  private final Map<String, StateTransitionManager<?, ?>> managers = ImmutableMap.<String, StateTransitionManager<?, ?>>builder()
+          .put(CASE_ENTITY, caseStateTransitionManager())
+          .put(CASE_GROUP, caseGroupStateTransitionManager())
+          .build();
 
-  /**
-   * Create and init the factory with concrete StateTransitionManagers for each
-   * required entity
-   */
-  public CaseSvcStateTransitionManagerFactory() {
-    managers = new HashMap<>();
+  private StateTransitionManager<CaseState, CaseEvent> caseStateTransitionManager() {
+    ImmutableTable.Builder<CaseState, CaseEvent, CaseState> builder = ImmutableTable.builder();
 
-    Map<CaseState, Map<CaseEvent, CaseState>> transitions = new HashMap<>();
+    // From sample init on activated to actionable
+    builder.put(CaseState.SAMPLED_INIT, CaseEvent.ACTIVATED, CaseState.ACTIONABLE);
 
-    Map<CaseEvent, CaseState> transitionMapForSampledInit = new HashMap<>();
-    transitionMapForSampledInit.put(CaseEvent.ACTIVATED, CaseState.ACTIONABLE);
-    transitions.put(CaseState.SAMPLED_INIT, transitionMapForSampledInit);
+    // From replacement init on replaced to actionable
+    builder.put(CaseState.REPLACEMENT_INIT, CaseEvent.REPLACED, CaseState.ACTIONABLE);
 
-    Map<CaseEvent, CaseState> transitionMapForReplacementInit = new HashMap<>();
-    transitionMapForReplacementInit.put(CaseEvent.REPLACED, CaseState.ACTIONABLE);
-    transitions.put(CaseState.REPLACEMENT_INIT, transitionMapForReplacementInit);
+    // From actionable on account created, deactivated, disabled to actionable, inactionable
+    builder.put(CaseState.ACTIONABLE, CaseEvent.ACCOUNT_CREATED, CaseState.ACTIONABLE);
+    builder.put(CaseState.ACTIONABLE, CaseEvent.DEACTIVATED, CaseState.INACTIONABLE);
+    builder.put(CaseState.ACTIONABLE, CaseEvent.DISABLED, CaseState.INACTIONABLE);
 
-    Map<CaseEvent, CaseState> transitionMapForActionable = new HashMap<>();
-    transitionMapForActionable.put(CaseEvent.ACCOUNT_CREATED, CaseState.ACTIONABLE);
-    transitionMapForActionable.put(CaseEvent.DEACTIVATED, CaseState.INACTIONABLE);
-    transitionMapForActionable.put(CaseEvent.DISABLED, CaseState.INACTIONABLE);
-    transitions.put(CaseState.ACTIONABLE, transitionMapForActionable);
+    // From inactionable on deactivated, disabled to inactionable
+    builder.put(CaseState.INACTIONABLE, CaseEvent.DEACTIVATED, CaseState.INACTIONABLE);
+    builder.put(CaseState.INACTIONABLE, CaseEvent.DISABLED, CaseState.INACTIONABLE);
 
-    Map<CaseEvent, CaseState> transitionMapForInactionable = new HashMap<>();
-    transitionMapForInactionable.put(CaseEvent.DEACTIVATED, CaseState.INACTIONABLE);
-    transitionMapForInactionable.put(CaseEvent.DISABLED, CaseState.INACTIONABLE);
-    transitions.put(CaseState.INACTIONABLE, transitionMapForInactionable);
+    return new BasicStateTransitionManager<>(builder.build().rowMap());
+  }
 
-    StateTransitionManager<CaseState, CaseEvent> caseStateTransitionManager =
-            new BasicStateTransitionManager<>(transitions);
+  private StateTransitionManager<CaseGroupStatus, CategoryDTO.CategoryName> caseGroupStateTransitionManager() {
+    ImmutableTable.Builder<CaseGroupStatus, CategoryDTO.CategoryName, CaseGroupStatus> builder = ImmutableTable.builder();
 
-    managers.put(CASE_ENTITY, caseStateTransitionManager);
+    // From not started on ci downloaded, successful response upload, completed by phone to in progress, completed, completed by phone
+    builder.put(CaseGroupStatus.NOTSTARTED, CategoryDTO.CategoryName.COLLECTION_INSTRUMENT_DOWNLOADED, CaseGroupStatus.INPROGRESS);
+    builder.put(CaseGroupStatus.NOTSTARTED, CategoryDTO.CategoryName.SUCCESSFUL_RESPONSE_UPLOAD, CaseGroupStatus.COMPLETE);
+    builder.put(CaseGroupStatus.NOTSTARTED, CategoryDTO.CategoryName.COMPLETED_BY_PHONE, CaseGroupStatus.COMPLETEDBYPHONE);
 
-    //CASE GROUP TRANSITIONS
-    Map<CaseGroupStatus, Map<CategoryDTO.CategoryName, CaseGroupStatus>> caseGroupTransitions = new HashMap<>();
+    // From in progress on successful response upload, completed by phone to completed, completed by phone
+    builder.put(CaseGroupStatus.INPROGRESS, CategoryDTO.CategoryName.SUCCESSFUL_RESPONSE_UPLOAD, CaseGroupStatus.COMPLETE);
+    builder.put(CaseGroupStatus.INPROGRESS, CategoryDTO.CategoryName.COMPLETED_BY_PHONE, CaseGroupStatus.COMPLETEDBYPHONE);
 
-    //Transition from NOTSTARTED TO INPROGRESS
-    //TODO: Update with transitions for EQ's and Non-seft surveys
-    Map<CategoryDTO.CategoryName, CaseGroupStatus> transitionMapForCaseStarted = new HashMap<>();
-    transitionMapForCaseStarted.put(CategoryDTO.CategoryName.COLLECTION_INSTRUMENT_DOWNLOADED,
-            CaseGroupStatus.INPROGRESS);
-    transitionMapForCaseStarted.put(CategoryDTO.CategoryName.SUCCESSFUL_RESPONSE_UPLOAD,
-            CaseGroupStatus.COMPLETE);
-    caseGroupTransitions.put(CaseGroupStatus.NOTSTARTED, transitionMapForCaseStarted);
+    // From reopened on completed by phone to completed by phone
+    builder.put(CaseGroupStatus.REOPENED, CategoryDTO.CategoryName.COMPLETED_BY_PHONE, CaseGroupStatus.COMPLETEDBYPHONE);
 
-    //Transition from INPROGRESS to COMPLETED
-    //TODO: Update with transitions for EQ's and Non-seft surveys
-    Map<CategoryDTO.CategoryName, CaseGroupStatus> transitionMapForCaseInProgress = new HashMap<>();
-    transitionMapForCaseInProgress.put(CategoryDTO.CategoryName.SUCCESSFUL_RESPONSE_UPLOAD, CaseGroupStatus.COMPLETE);
-    caseGroupTransitions.put(CaseGroupStatus.INPROGRESS, transitionMapForCaseInProgress);
-
-    StateTransitionManager<CaseGroupStatus, CategoryDTO.CategoryName> caseGroupStatusTransitionManager =
-            new BasicStateTransitionManager<>(caseGroupTransitions);
-
-    managers.put(CASE_GROUP, caseGroupStatusTransitionManager);
+    return new BasicStateTransitionManager<>(builder.build().rowMap());
   }
 
   @SuppressWarnings("unchecked")

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/utility/Constants.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/utility/Constants.java
@@ -9,4 +9,5 @@ import net.sourceforge.cobertura.CoverageIgnore;
 public class Constants {
   public static final String QUESTIONNAIRE_RESPONSE = "Questionnaire response";
   public static final String SYSTEM = "SYSTEM";
+  public static final String USER = "USER";
 }

--- a/src/main/resources/database/changes/release-10.52.0/add_completed_by_phone_category.sql
+++ b/src/main/resources/database/changes/release-10.52.0/add_completed_by_phone_category.sql
@@ -1,0 +1,1 @@
+INSERT INTO casesvc.category (categorypk, shortdescription, longdescription, eventtype, role, generatedactiontype, "group", oldcasesampleunittypes, newcasesampleunittype, recalccollectioninstrument) VALUES ('COMPLETED_BY_PHONE', 'Completed By Phone', 'Completed By Phone', 'DEACTIVATED',  NULL, NULL, NULL, 'B,BI', NULL, NULL);

--- a/src/main/resources/database/changes/release-10.52.0/changelog.yml
+++ b/src/main/resources/database/changes/release-10.52.0/changelog.yml
@@ -9,3 +9,12 @@ databaseChangeLog:
             path: constrain_case_group_status_not_null.sql
             relativeToChangelogFile: true
             splitStatements: false
+  - changeSet:
+      id: 10.52.0-2
+      author: Ben Jefferies
+      changes:
+        - sqlFile:
+            comment: Add category for case event when completed by phone
+            path: add_completed_by_phone_category.sql
+            relativeToChangelogFile: true
+            splitStatements: false

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpointUnitTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpointUnitTest.java
@@ -37,8 +37,8 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.Is.isA;
@@ -51,11 +51,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.ons.ctp.common.MvcHelper.getJson;
 import static uk.gov.ons.ctp.common.MvcHelper.postJson;
-import static uk.gov.ons.ctp.common.TestHelper.createTestDate;
 import static uk.gov.ons.ctp.common.utility.MockMvcControllerAdviceHelper.mockAdviceFor;
 import static uk.gov.ons.ctp.response.casesvc.endpoint.CaseEndpoint.CATEGORY_ACCESS_CODE_AUTHENTICATION_ATTEMPT_NOT_FOUND;
 import static uk.gov.ons.ctp.response.casesvc.endpoint.CaseEndpoint.ERRORMSG_CASENOTFOUND;
-import static uk.gov.ons.ctp.response.casesvc.endpoint.CaseGroupEndpoint.ERRORMSG_CASEGROUPNOTFOUND;
 import static uk.gov.ons.ctp.response.casesvc.utility.Constants.SYSTEM;
 
 /**
@@ -440,7 +438,7 @@ public final class CaseEndpointUnitTest {
     actions.andExpect(handler().handlerType(CaseEndpoint.class));
     actions.andExpect(handler().methodName("findCasesInCaseGroup"));
     actions.andExpect(jsonPath("$.error.code", is(CTPException.Fault.RESOURCE_NOT_FOUND.name())));
-    actions.andExpect(jsonPath("$.error.message", is(String.format("%s casegroup id %s", ERRORMSG_CASEGROUPNOTFOUND,
+    actions.andExpect(jsonPath("$.error.message", is(String.format("CaseGroup not found for casegroup id %s",
             NON_EXISTING_CASE_GROUP_UUID))));
     actions.andExpect(jsonPath("$.error.timestamp", isA(String.class)));
   }

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseGroupEndpointUnitTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseGroupEndpointUnitTest.java
@@ -19,13 +19,20 @@ import uk.gov.ons.ctp.common.error.RestExceptionHandler;
 import uk.gov.ons.ctp.common.jackson.CustomObjectMapper;
 import uk.gov.ons.ctp.common.state.StateTransitionManager;
 import uk.gov.ons.ctp.response.casesvc.CaseSvcBeanMapper;
+import uk.gov.ons.ctp.response.casesvc.domain.model.Case;
+import uk.gov.ons.ctp.response.casesvc.domain.model.CaseEvent;
 import uk.gov.ons.ctp.response.casesvc.domain.model.CaseGroup;
+import uk.gov.ons.ctp.response.casesvc.domain.model.Category;
 import uk.gov.ons.ctp.response.casesvc.representation.CaseGroupDTO;
 import uk.gov.ons.ctp.response.casesvc.representation.CaseGroupStatus;
 import uk.gov.ons.ctp.response.casesvc.representation.CategoryDTO;
 import uk.gov.ons.ctp.response.casesvc.service.CaseGroupService;
+import uk.gov.ons.ctp.response.casesvc.service.CaseService;
+import uk.gov.ons.ctp.response.casesvc.service.CategoryService;
 import uk.gov.ons.ctp.response.casesvc.state.CaseSvcStateTransitionManagerFactory;
+import uk.gov.ons.ctp.response.casesvc.utility.Constants;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
 
@@ -46,238 +53,265 @@ import static uk.gov.ons.ctp.common.utility.MockMvcControllerAdviceHelper.mockAd
  */
 public final class CaseGroupEndpointUnitTest {
 
-  @InjectMocks
-  private CaseGroupEndpoint caseGroupEndpoint;
+    @InjectMocks
+    private CaseGroupEndpoint caseGroupEndpoint;
 
-  @Mock
-  private CaseGroupService caseGroupService;
+    @Mock
+    private CaseGroupService caseGroupService;
 
-  @Spy
-  private MapperFacade mapperFacade = new CaseSvcBeanMapper();
+    @Mock
+    private CaseService caseService;
 
-  @Spy
-  @SuppressWarnings("unchecked")
-  private StateTransitionManager<CaseGroupStatus, CategoryDTO.CategoryName> stm = (StateTransitionManager<CaseGroupStatus, CategoryDTO.CategoryName>)
-      new CaseSvcStateTransitionManagerFactory().getStateTransitionManager(CaseSvcStateTransitionManagerFactory.CASE_GROUP);
+    @Mock
+    private CategoryService categoryService;
 
-  private MockMvc mockMvc;
+    @Spy
+    private MapperFacade mapperFacade = new CaseSvcBeanMapper();
 
-  private static final UUID CASE_GROUP_UUID = UUID.randomUUID();
-  private static final String NON_EXISTENT_CASE_GROUP_UUID =
-      "9a5f2be5-f944-41f9-982c-3517cfcfe666";
-  private static final UUID CASE_GROUP_UUID_UNCHECKED_EXCEPTION =
-      UUID.randomUUID();
-  private static final UUID CASE_GROUP_CE_ID =
-      UUID.fromString("dab9db7f-3aa0-4866-be20-54d72ee185fb");
-  private static final UUID CASE_GROUP_PARTY_ID =
-      UUID.fromString("3b136c4b-7a14-4904-9e01-13364dd7b972");
-  private static final String CASE_GROUP_SU_REF = "0123456789";
-  private static final String CASE_GROUP_SU_TYPE = "B";
-  private static final String OUR_EXCEPTION_MESSAGE = "this is what we throw";
+    @Spy
+    @SuppressWarnings("unchecked")
+    private StateTransitionManager<CaseGroupStatus, CategoryDTO.CategoryName> stm = (StateTransitionManager<CaseGroupStatus, CategoryDTO.CategoryName>)
+            new CaseSvcStateTransitionManagerFactory().getStateTransitionManager(CaseSvcStateTransitionManagerFactory.CASE_GROUP);
 
-  /**
-   * Initialises Mockito
-   *
-   * @throws Exception exception thrown
-   */
-  @Before
-  public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
+    private MockMvc mockMvc;
 
-    this.mockMvc = MockMvcBuilders
-        .standaloneSetup(caseGroupEndpoint)
-        .setHandlerExceptionResolvers(mockAdviceFor(
-            RestExceptionHandler.class))
-        .setMessageConverters(new MappingJackson2HttpMessageConverter(
-            new CustomObjectMapper()))
-        .build();
-  }
+    private static final UUID CASE_GROUP_UUID = UUID.randomUUID();
+    private static final String NON_EXISTENT_CASE_GROUP_UUID =
+            "9a5f2be5-f944-41f9-982c-3517cfcfe666";
+    private static final UUID CASE_GROUP_UUID_UNCHECKED_EXCEPTION =
+            UUID.randomUUID();
+    private static final UUID CASE_GROUP_CE_ID =
+            UUID.fromString("dab9db7f-3aa0-4866-be20-54d72ee185fb");
+    private static final UUID CASE_GROUP_PARTY_ID =
+            UUID.fromString("3b136c4b-7a14-4904-9e01-13364dd7b972");
+    private static final String CASE_GROUP_SU_REF = "0123456789";
+    private static final String CASE_GROUP_SU_TYPE = "B";
+    private static final String OUR_EXCEPTION_MESSAGE = "this is what we throw";
 
-  /**
-   * Tests whether casegroup is found by id
-   *
-   * @throws Exception exception thrown
-   */
-  @Test
-  public void findCaseGroupById() throws Exception {
-    CaseGroup result = CaseGroup.builder().id(CASE_GROUP_UUID)
-        .collectionExerciseId(CASE_GROUP_CE_ID)
-        .partyId(CASE_GROUP_PARTY_ID)
-        .sampleUnitRef(CASE_GROUP_SU_REF)
-        .sampleUnitType(CASE_GROUP_SU_TYPE).status(CaseGroupStatus.COMPLETE).build();
-    when(caseGroupService.findCaseGroupById(CASE_GROUP_UUID)).
-        thenReturn(result);
+    /**
+     * Initialises Mockito
+     *
+     * @throws Exception exception thrown
+     */
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
 
-    ResultActions actions = mockMvc.perform(getJson(
-        String.format("/casegroups/%s", CASE_GROUP_UUID)));
+        this.mockMvc = MockMvcBuilders
+                .standaloneSetup(caseGroupEndpoint)
+                .setHandlerExceptionResolvers(mockAdviceFor(
+                        RestExceptionHandler.class))
+                .setMessageConverters(new MappingJackson2HttpMessageConverter(
+                        new CustomObjectMapper()))
+                .build();
+    }
 
-    actions.andExpect(status().isOk());
-    actions.andExpect(handler().handlerType(CaseGroupEndpoint.class));
-    actions.andExpect(handler().methodName("findCaseGroupById"));
-    actions.andExpect(jsonPath("$.id",
-        is(CASE_GROUP_UUID.toString())));
-    actions.andExpect(jsonPath("$.collectionExerciseId",
-        is(CASE_GROUP_CE_ID.toString())));
-    actions.andExpect(jsonPath("$.partyId",
-        is(CASE_GROUP_PARTY_ID.toString())));
-    actions.andExpect(jsonPath("$.sampleUnitRef",
-        is(CASE_GROUP_SU_REF)));
-    actions.andExpect(jsonPath("$.sampleUnitType",
-        is(CASE_GROUP_SU_TYPE)));
-    actions.andExpect(jsonPath("$.caseGroupStatus",
-        is(CaseGroupStatus.COMPLETE.toString())));
-  }
+    /**
+     * Tests whether casegroup is found by id
+     *
+     * @throws Exception exception thrown
+     */
+    @Test
+    public void findCaseGroupById() throws Exception {
+        CaseGroup result = CaseGroup.builder().id(CASE_GROUP_UUID)
+                .collectionExerciseId(CASE_GROUP_CE_ID)
+                .partyId(CASE_GROUP_PARTY_ID)
+                .sampleUnitRef(CASE_GROUP_SU_REF)
+                .sampleUnitType(CASE_GROUP_SU_TYPE).status(CaseGroupStatus.COMPLETE).build();
+        when(caseGroupService.findCaseGroupById(CASE_GROUP_UUID)).
+                thenReturn(result);
 
-  /**
-   * Tests whether casegroup is not found by id
-   *
-   * @throws Exception exception thrown
-   */
-  @Test
-  public void findCaseGroupByIdNotFound() throws Exception {
-    ResultActions actions = mockMvc.perform(getJson(
-        String.format("/casegroups/%s", NON_EXISTENT_CASE_GROUP_UUID)));
+        ResultActions actions = mockMvc.perform(getJson(
+                String.format("/casegroups/%s", CASE_GROUP_UUID)));
 
-    actions.andExpect(status().isNotFound());
-    actions.andExpect(handler().handlerType(CaseGroupEndpoint.class));
-    actions.andExpect(handler().methodName("findCaseGroupById"));
-    actions.andExpect(jsonPath("$.error.code",
-        is(CTPException.Fault.RESOURCE_NOT_FOUND.name())));
-    actions.andExpect(jsonPath("$.error.message",
-        is(String.format("CaseGroup not found for casegroup id %s",
-            NON_EXISTENT_CASE_GROUP_UUID))));
-    actions.andExpect(jsonPath("$.error.timestamp",
-        isA(String.class)));
-  }
+        actions.andExpect(status().isOk());
+        actions.andExpect(handler().handlerType(CaseGroupEndpoint.class));
+        actions.andExpect(handler().methodName("findCaseGroupById"));
+        actions.andExpect(jsonPath("$.id",
+                is(CASE_GROUP_UUID.toString())));
+        actions.andExpect(jsonPath("$.collectionExerciseId",
+                is(CASE_GROUP_CE_ID.toString())));
+        actions.andExpect(jsonPath("$.partyId",
+                is(CASE_GROUP_PARTY_ID.toString())));
+        actions.andExpect(jsonPath("$.sampleUnitRef",
+                is(CASE_GROUP_SU_REF)));
+        actions.andExpect(jsonPath("$.sampleUnitType",
+                is(CASE_GROUP_SU_TYPE)));
+        actions.andExpect(jsonPath("$.caseGroupStatus",
+                is(CaseGroupStatus.COMPLETE.toString())));
+    }
 
-  /**
-   * Tests whether casegroup is found by id with an unchecked exception
-   *
-   * @throws Exception exception thrown
-   */
-  @Test
-  public void findCaseGroupByIdUnCheckedException() throws Exception {
-    when(caseGroupService.
-        findCaseGroupById(CASE_GROUP_UUID_UNCHECKED_EXCEPTION)).
-        thenThrow(new IllegalArgumentException(OUR_EXCEPTION_MESSAGE));
+    /**
+     * Tests whether casegroup is not found by id
+     *
+     * @throws Exception exception thrown
+     */
+    @Test
+    public void findCaseGroupByIdNotFound() throws Exception {
+        ResultActions actions = mockMvc.perform(getJson(
+                String.format("/casegroups/%s", NON_EXISTENT_CASE_GROUP_UUID)));
 
-    ResultActions actions = mockMvc.perform(getJson(
-        String.format("/casegroups/%s", CASE_GROUP_UUID_UNCHECKED_EXCEPTION)));
+        actions.andExpect(status().isNotFound());
+        actions.andExpect(handler().handlerType(CaseGroupEndpoint.class));
+        actions.andExpect(handler().methodName("findCaseGroupById"));
+        actions.andExpect(jsonPath("$.error.code",
+                is(CTPException.Fault.RESOURCE_NOT_FOUND.name())));
+        actions.andExpect(jsonPath("$.error.message",
+                is(String.format("CaseGroup not found for casegroup id %s",
+                        NON_EXISTENT_CASE_GROUP_UUID))));
+        actions.andExpect(jsonPath("$.error.timestamp",
+                isA(String.class)));
+    }
 
-    actions.andExpect(status().is5xxServerError());
-    actions.andExpect(handler().handlerType(CaseGroupEndpoint.class));
-    actions.andExpect(handler().methodName("findCaseGroupById"));
-    actions.andExpect(jsonPath("$.error.code",
-        is(CTPException.Fault.SYSTEM_ERROR.name())));
-    actions.andExpect(jsonPath("$.error.message",
-        is(OUR_EXCEPTION_MESSAGE)));
-    actions.andExpect(jsonPath("$.error.timestamp",
-        isA(String.class)));
-  }
+    /**
+     * Tests whether casegroup is found by id with an unchecked exception
+     *
+     * @throws Exception exception thrown
+     */
+    @Test
+    public void findCaseGroupByIdUnCheckedException() throws Exception {
+        when(caseGroupService.
+                findCaseGroupById(CASE_GROUP_UUID_UNCHECKED_EXCEPTION)).
+                thenThrow(new IllegalArgumentException(OUR_EXCEPTION_MESSAGE));
+
+        ResultActions actions = mockMvc.perform(getJson(
+                String.format("/casegroups/%s", CASE_GROUP_UUID_UNCHECKED_EXCEPTION)));
+
+        actions.andExpect(status().is5xxServerError());
+        actions.andExpect(handler().handlerType(CaseGroupEndpoint.class));
+        actions.andExpect(handler().methodName("findCaseGroupById"));
+        actions.andExpect(jsonPath("$.error.code",
+                is(CTPException.Fault.SYSTEM_ERROR.name())));
+        actions.andExpect(jsonPath("$.error.message",
+                is(OUR_EXCEPTION_MESSAGE)));
+        actions.andExpect(jsonPath("$.error.timestamp",
+                isA(String.class)));
+    }
 
 
-  /**
-   * Test available case group transitions are found by collection exercise Id and RU ref
-   *
-   * @throws Exception exception thrown
-   */
-  @Test
-  public void givenCollexIdAndRuRefWhenRequestForCaseGroupTransitionsThenAvailableCaseGroupTransitionsReturned() throws Exception {
-    // Given
-    CaseGroup result = CaseGroup.builder()
-        .id(CASE_GROUP_UUID)
-        .collectionExerciseId(CASE_GROUP_CE_ID)
-        .partyId(CASE_GROUP_PARTY_ID)
-        .sampleUnitRef(CASE_GROUP_SU_REF)
-        .sampleUnitType(CASE_GROUP_SU_TYPE)
-        .status(CaseGroupStatus.NOTSTARTED).build();
+    /**
+     * Test available case group transitions are found by collection exercise Id and RU ref
+     *
+     * @throws Exception exception thrown
+     */
+    @Test
+    public void givenCollexIdAndRuRefWhenRequestForCaseGroupTransitionsThenAvailableCaseGroupTransitionsReturned() throws Exception {
+        // Given
+        CaseGroup result = CaseGroup.builder()
+                .id(CASE_GROUP_UUID)
+                .collectionExerciseId(CASE_GROUP_CE_ID)
+                .partyId(CASE_GROUP_PARTY_ID)
+                .sampleUnitRef(CASE_GROUP_SU_REF)
+                .sampleUnitType(CASE_GROUP_SU_TYPE)
+                .status(CaseGroupStatus.NOTSTARTED).build();
 
-    when(caseGroupService.findCaseGroupByCollectionExerciseIdAndRuRef(CASE_GROUP_CE_ID, CASE_GROUP_SU_REF)).thenReturn(result);
+        when(caseGroupService.findCaseGroupByCollectionExerciseIdAndRuRef(CASE_GROUP_CE_ID, CASE_GROUP_SU_REF)).thenReturn(result);
 
-    // When
-    ResultActions actions = mockMvc.perform(getJson(
-        String.format("/casegroups/transitions/%s/%s", CASE_GROUP_CE_ID, CASE_GROUP_SU_REF)));
+        // When
+        ResultActions actions = mockMvc.perform(getJson(
+                String.format("/casegroups/transitions/%s/%s", CASE_GROUP_CE_ID, CASE_GROUP_SU_REF)));
 
-    // Then
-    actions.andExpect(status().isOk());
+        // Then
+        actions.andExpect(status().isOk());
 
-    String availableTransitionsString = actions.andReturn().getResponse().getContentAsString();
-    Map<CategoryDTO.CategoryName, CaseGroupStatus> availableTransitions = new ObjectMapper()
-        .readValue(availableTransitionsString, new TypeReference<Map<CategoryDTO.CategoryName, CaseGroupStatus>>() {});
-    assertThat(availableTransitions, hasEntry(CategoryDTO.CategoryName.COLLECTION_INSTRUMENT_DOWNLOADED, CaseGroupStatus.INPROGRESS));
-    assertThat(availableTransitions, hasEntry(CategoryDTO.CategoryName.SUCCESSFUL_RESPONSE_UPLOAD, CaseGroupStatus.COMPLETE));
-    assertThat(availableTransitions, hasEntry(CategoryDTO.CategoryName.COMPLETED_BY_PHONE, CaseGroupStatus.COMPLETEDBYPHONE));
-  }
+        String availableTransitionsString = actions.andReturn().getResponse().getContentAsString();
+        Map<CategoryDTO.CategoryName, CaseGroupStatus> availableTransitions = new ObjectMapper()
+                .readValue(availableTransitionsString, new TypeReference<Map<CategoryDTO.CategoryName, CaseGroupStatus>>() {
+                });
+        assertThat(availableTransitions, hasEntry(CategoryDTO.CategoryName.COLLECTION_INSTRUMENT_DOWNLOADED, CaseGroupStatus.INPROGRESS));
+        assertThat(availableTransitions, hasEntry(CategoryDTO.CategoryName.SUCCESSFUL_RESPONSE_UPLOAD, CaseGroupStatus.COMPLETE));
+        assertThat(availableTransitions, hasEntry(CategoryDTO.CategoryName.COMPLETED_BY_PHONE, CaseGroupStatus.COMPLETEDBYPHONE));
+    }
 
-  /**
-   * Test available case group transitions not found
-   *
-   * @throws Exception exception thrown
-   */
-  @Test
-  public void givenInvalidCollexIdAndRuRefWhenRequestForCaseGroupTransitionsThenCaseGroupNotFound() throws Exception {
-    // Given
-    String nonExistentCollexId = UUID.randomUUID().toString();
-    String nonExistentRuRef = "11111111111";
+    /**
+     * Test available case group transitions not found
+     *
+     * @throws Exception exception thrown
+     */
+    @Test
+    public void givenInvalidCollexIdAndRuRefWhenRequestForCaseGroupTransitionsThenCaseGroupNotFound() throws Exception {
+        // Given
+        String nonExistentCollexId = UUID.randomUUID().toString();
+        String nonExistentRuRef = "11111111111";
 
-    // When
-    ResultActions actions = mockMvc.perform(getJson(
-        String.format("/casegroups/transitions/%s/%s", nonExistentCollexId, nonExistentRuRef)));
+        // When
+        ResultActions actions = mockMvc.perform(getJson(
+                String.format("/casegroups/transitions/%s/%s", nonExistentCollexId, nonExistentRuRef)));
 
-    // Then
-    actions.andExpect(status().isNotFound());
-   }
+        // Then
+        actions.andExpect(status().isNotFound());
+    }
 
-  /**
-   * Test case group status transition is successful
-   *
-   * @throws Exception exception thrown
-   */
-  @Test
-  public void givenCollexIdRuRefAndCaseEventWhenChangeCaseGroupStatusThenSuccess() throws Exception {
-    // Given
-    CaseGroup caseGroupResult = CaseGroup.builder()
-        .id(CASE_GROUP_UUID)
-        .collectionExerciseId(CASE_GROUP_CE_ID)
-        .partyId(CASE_GROUP_PARTY_ID)
-        .sampleUnitRef(CASE_GROUP_SU_REF)
-        .sampleUnitType(CASE_GROUP_SU_TYPE)
-        .status(CaseGroupStatus.NOTSTARTED).build();
-    when(caseGroupService.findCaseGroupByCollectionExerciseIdAndRuRef(CASE_GROUP_CE_ID, CASE_GROUP_SU_REF)).thenReturn(caseGroupResult);
+    /**
+     * Test case group status transition is successful
+     *
+     * @throws Exception exception thrown
+     */
+    @Test
+    public void givenCollexIdRuRefAndCaseEventWhenChangeCaseGroupStatusThenSuccess() throws Exception {
+        // Given
+        CaseGroup caseGroupResult = CaseGroup.builder()
+                .id(CASE_GROUP_UUID)
+                .collectionExerciseId(CASE_GROUP_CE_ID)
+                .partyId(CASE_GROUP_PARTY_ID)
+                .sampleUnitRef(CASE_GROUP_SU_REF)
+                .sampleUnitType(CASE_GROUP_SU_TYPE)
+                .status(CaseGroupStatus.NOTSTARTED).build();
+        when(caseGroupService.findCaseGroupByCollectionExerciseIdAndRuRef(CASE_GROUP_CE_ID, CASE_GROUP_SU_REF)).thenReturn(caseGroupResult);
+        Case aCase = Case.builder().build();
+        when(caseService.findCasesByCaseGroupFK(caseGroupResult.getCaseGroupPK())).thenReturn(Collections.singletonList(aCase));
+        when(categoryService.findCategory(CategoryDTO.CategoryName.COMPLETED_BY_PHONE)).thenReturn(Category.builder().build());
 
-    CategoryDTO.CategoryName categoryName = CategoryDTO.CategoryName.COMPLETED_BY_PHONE;
+        CategoryDTO.CategoryName categoryName = CategoryDTO.CategoryName.COMPLETED_BY_PHONE;
+        CaseGroupEvent caseGroupEvent = new CaseGroupEvent();
+        caseGroupEvent.setEvent("COMPLETED_BY_PHONE");
 
-    // When
-    CaseGroupEvent caseGroupEvent = new CaseGroupEvent();
-    caseGroupEvent.setEvent("COMPLETED_BY_PHONE");
-    ResultActions actions = mockMvc.perform(putJson(
-        String.format("/casegroups/transitions/%s/%s", CASE_GROUP_CE_ID,
-            CASE_GROUP_SU_REF), new ObjectMapper().writeValueAsString(caseGroupEvent)));
+        // When
+        ResultActions actions = mockMvc.perform(putJson(
+                String.format("/casegroups/transitions/%s/%s", CASE_GROUP_CE_ID, CASE_GROUP_SU_REF),
+                new ObjectMapper().writeValueAsString(caseGroupEvent)));
 
-    // Then
-    actions.andExpect(status().isOk());
-    verify(caseGroupService).transitionCaseGroupStatus(caseGroupResult, categoryName, CASE_GROUP_PARTY_ID);
-  }
+        // Then
+        actions.andExpect(status().isOk());
+        CaseEvent caseEvent = CaseEvent.builder().createdBy(Constants.USER).category(CategoryDTO.CategoryName.COMPLETED_BY_PHONE).build();
+        verify(caseService).createCaseEvent(caseEvent, aCase);
+    }
 
-  /**
-   * Test case group status transition not found
-   *
-   * @throws Exception exception thrown
-   */
-  @Test
-  public void givenInvalidCollexIdPartyIdAndRuRefWhenPutCaseGroupTransitionThenCaseGroupTransitionNotFound() throws Exception {
-    // Given
-    String nonExistentCollexId = UUID.randomUUID().toString();
-    String nonExistentPartyId = UUID.randomUUID().toString();
-    String nonExistentRuRef = "11111111111";
-    CategoryDTO.CategoryName categoryName = CategoryDTO.CategoryName.COMPLETED_BY_PHONE;
+    @Test
+    public void givenInvalidEventWhenUpdateStateThenBadRequest() throws Exception {
+        // Given
+        CategoryDTO.CategoryName categoryName = CategoryDTO.CategoryName.COMPLETED_BY_PHONE;
+        CaseGroupEvent caseGroupEvent = new CaseGroupEvent();
+        caseGroupEvent.setEvent("INVALID_EVENT");
 
-    // When
-    ResultActions actions = mockMvc.perform(putJson(
-        String.format("/casegroups/transitions/%s/%s/%s/%s", nonExistentCollexId, nonExistentPartyId,
-            nonExistentRuRef, categoryName), ""));
+        // When
+        ResultActions actions = mockMvc.perform(putJson(
+                String.format("/casegroups/transitions/%s/%s", CASE_GROUP_CE_ID, CASE_GROUP_SU_REF),
+                new ObjectMapper().writeValueAsString(caseGroupEvent)));
 
-    // Then
-    actions.andExpect(status().isNotFound());
-  }
+        // Then
+        actions.andExpect(status().isBadRequest());
+    }
+
+    /**
+     * Test case group status transition not found
+     *
+     * @throws Exception exception thrown
+     */
+    @Test
+    public void givenInvalidCollexIdPartyIdAndRuRefWhenPutCaseGroupTransitionThenCaseGroupTransitionNotFound() throws Exception {
+        // Given
+        String nonExistentCollexId = UUID.randomUUID().toString();
+        String nonExistentPartyId = UUID.randomUUID().toString();
+        String nonExistentRuRef = "11111111111";
+        CategoryDTO.CategoryName categoryName = CategoryDTO.CategoryName.COMPLETED_BY_PHONE;
+
+        // When
+        ResultActions actions = mockMvc.perform(putJson(
+                String.format("/casegroups/transitions/%s/%s/%s/%s", nonExistentCollexId, nonExistentPartyId,
+                        nonExistentRuRef, categoryName), ""));
+
+        // Then
+        actions.andExpect(status().isNotFound());
+    }
 }

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseGroupEndpointUnitTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseGroupEndpointUnitTest.java
@@ -1,8 +1,9 @@
 package uk.gov.ons.ctp.response.casesvc.endpoint;
 
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import ma.glasnost.orika.MapperFacade;
-import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InjectMocks;
@@ -16,20 +17,28 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.common.error.RestExceptionHandler;
 import uk.gov.ons.ctp.common.jackson.CustomObjectMapper;
+import uk.gov.ons.ctp.common.state.StateTransitionManager;
 import uk.gov.ons.ctp.response.casesvc.CaseSvcBeanMapper;
 import uk.gov.ons.ctp.response.casesvc.domain.model.CaseGroup;
+import uk.gov.ons.ctp.response.casesvc.representation.CaseGroupDTO;
 import uk.gov.ons.ctp.response.casesvc.representation.CaseGroupStatus;
+import uk.gov.ons.ctp.response.casesvc.representation.CategoryDTO;
 import uk.gov.ons.ctp.response.casesvc.service.CaseGroupService;
+import uk.gov.ons.ctp.response.casesvc.state.CaseSvcStateTransitionManagerFactory;
 
+import java.util.Map;
 import java.util.UUID;
 
+import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.Is.isA;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.contains;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.handler;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static uk.gov.ons.ctp.common.MvcHelper.getJson;
+import static uk.gov.ons.ctp.common.MvcHelper.putJson;
 import static uk.gov.ons.ctp.common.utility.MockMvcControllerAdviceHelper.mockAdviceFor;
 
 /**
@@ -46,23 +55,29 @@ public final class CaseGroupEndpointUnitTest {
   @Spy
   private MapperFacade mapperFacade = new CaseSvcBeanMapper();
 
+  @Spy
+  @SuppressWarnings("unchecked")
+  private StateTransitionManager<CaseGroupStatus, CategoryDTO.CategoryName> stm = (StateTransitionManager<CaseGroupStatus, CategoryDTO.CategoryName>)
+      new CaseSvcStateTransitionManagerFactory().getStateTransitionManager(CaseSvcStateTransitionManagerFactory.CASE_GROUP);
+
   private MockMvc mockMvc;
 
   private static final UUID CASE_GROUP_UUID = UUID.randomUUID();
   private static final String NON_EXISTENT_CASE_GROUP_UUID =
-          "9a5f2be5-f944-41f9-982c-3517cfcfe666";
+      "9a5f2be5-f944-41f9-982c-3517cfcfe666";
   private static final UUID CASE_GROUP_UUID_UNCHECKED_EXCEPTION =
-          UUID.randomUUID();
+      UUID.randomUUID();
   private static final UUID CASE_GROUP_CE_ID =
-          UUID.fromString("dab9db7f-3aa0-4866-be20-54d72ee185fb");
+      UUID.fromString("dab9db7f-3aa0-4866-be20-54d72ee185fb");
   private static final UUID CASE_GROUP_PARTY_ID =
-          UUID.fromString("3b136c4b-7a14-4904-9e01-13364dd7b972");
+      UUID.fromString("3b136c4b-7a14-4904-9e01-13364dd7b972");
   private static final String CASE_GROUP_SU_REF = "0123456789";
   private static final String CASE_GROUP_SU_TYPE = "B";
   private static final String OUR_EXCEPTION_MESSAGE = "this is what we throw";
 
   /**
    * Initialises Mockito
+   *
    * @throws Exception exception thrown
    */
   @Before
@@ -70,90 +85,199 @@ public final class CaseGroupEndpointUnitTest {
     MockitoAnnotations.initMocks(this);
 
     this.mockMvc = MockMvcBuilders
-            .standaloneSetup(caseGroupEndpoint)
-            .setHandlerExceptionResolvers(mockAdviceFor(
-                    RestExceptionHandler.class))
-            .setMessageConverters(new MappingJackson2HttpMessageConverter(
-                    new CustomObjectMapper()))
-            .build();
+        .standaloneSetup(caseGroupEndpoint)
+        .setHandlerExceptionResolvers(mockAdviceFor(
+            RestExceptionHandler.class))
+        .setMessageConverters(new MappingJackson2HttpMessageConverter(
+            new CustomObjectMapper()))
+        .build();
   }
 
   /**
    * Tests whether casegroup is found by id
+   *
    * @throws Exception exception thrown
    */
   @Test
   public void findCaseGroupById() throws Exception {
     CaseGroup result = CaseGroup.builder().id(CASE_GROUP_UUID)
-            .collectionExerciseId(CASE_GROUP_CE_ID)
-            .partyId(CASE_GROUP_PARTY_ID)
-            .sampleUnitRef(CASE_GROUP_SU_REF)
-            .sampleUnitType(CASE_GROUP_SU_TYPE).status(CaseGroupStatus.COMPLETE).build();
+        .collectionExerciseId(CASE_GROUP_CE_ID)
+        .partyId(CASE_GROUP_PARTY_ID)
+        .sampleUnitRef(CASE_GROUP_SU_REF)
+        .sampleUnitType(CASE_GROUP_SU_TYPE).status(CaseGroupStatus.COMPLETE).build();
     when(caseGroupService.findCaseGroupById(CASE_GROUP_UUID)).
-            thenReturn(result);
+        thenReturn(result);
 
     ResultActions actions = mockMvc.perform(getJson(
-            String.format("/casegroups/%s", CASE_GROUP_UUID)));
+        String.format("/casegroups/%s", CASE_GROUP_UUID)));
 
     actions.andExpect(status().isOk());
     actions.andExpect(handler().handlerType(CaseGroupEndpoint.class));
     actions.andExpect(handler().methodName("findCaseGroupById"));
     actions.andExpect(jsonPath("$.id",
-            is(CASE_GROUP_UUID.toString())));
+        is(CASE_GROUP_UUID.toString())));
     actions.andExpect(jsonPath("$.collectionExerciseId",
-            is(CASE_GROUP_CE_ID.toString())));
+        is(CASE_GROUP_CE_ID.toString())));
     actions.andExpect(jsonPath("$.partyId",
-            is(CASE_GROUP_PARTY_ID.toString())));
+        is(CASE_GROUP_PARTY_ID.toString())));
     actions.andExpect(jsonPath("$.sampleUnitRef",
-            is(CASE_GROUP_SU_REF)));
+        is(CASE_GROUP_SU_REF)));
     actions.andExpect(jsonPath("$.sampleUnitType",
-            is(CASE_GROUP_SU_TYPE)));
+        is(CASE_GROUP_SU_TYPE)));
     actions.andExpect(jsonPath("$.caseGroupStatus",
-            is(CaseGroupStatus.COMPLETE.toString())));
+        is(CaseGroupStatus.COMPLETE.toString())));
   }
 
   /**
    * Tests whether casegroup is not found by id
+   *
    * @throws Exception exception thrown
    */
   @Test
   public void findCaseGroupByIdNotFound() throws Exception {
     ResultActions actions = mockMvc.perform(getJson(
-            String.format("/casegroups/%s", NON_EXISTENT_CASE_GROUP_UUID)));
+        String.format("/casegroups/%s", NON_EXISTENT_CASE_GROUP_UUID)));
 
     actions.andExpect(status().isNotFound());
     actions.andExpect(handler().handlerType(CaseGroupEndpoint.class));
     actions.andExpect(handler().methodName("findCaseGroupById"));
     actions.andExpect(jsonPath("$.error.code",
-            is(CTPException.Fault.RESOURCE_NOT_FOUND.name())));
+        is(CTPException.Fault.RESOURCE_NOT_FOUND.name())));
     actions.andExpect(jsonPath("$.error.message",
-            is(String.format("CaseGroup not found for casegroup id %s",
-                    NON_EXISTENT_CASE_GROUP_UUID))));
+        is(String.format("CaseGroup not found for casegroup id %s",
+            NON_EXISTENT_CASE_GROUP_UUID))));
     actions.andExpect(jsonPath("$.error.timestamp",
-            isA(String.class)));
+        isA(String.class)));
   }
 
   /**
    * Tests whether casegroup is found by id with an unchecked exception
+   *
    * @throws Exception exception thrown
    */
   @Test
   public void findCaseGroupByIdUnCheckedException() throws Exception {
     when(caseGroupService.
-            findCaseGroupById(CASE_GROUP_UUID_UNCHECKED_EXCEPTION)).
-            thenThrow(new IllegalArgumentException(OUR_EXCEPTION_MESSAGE));
+        findCaseGroupById(CASE_GROUP_UUID_UNCHECKED_EXCEPTION)).
+        thenThrow(new IllegalArgumentException(OUR_EXCEPTION_MESSAGE));
 
     ResultActions actions = mockMvc.perform(getJson(
-            String.format("/casegroups/%s", CASE_GROUP_UUID_UNCHECKED_EXCEPTION)));
+        String.format("/casegroups/%s", CASE_GROUP_UUID_UNCHECKED_EXCEPTION)));
 
     actions.andExpect(status().is5xxServerError());
     actions.andExpect(handler().handlerType(CaseGroupEndpoint.class));
     actions.andExpect(handler().methodName("findCaseGroupById"));
     actions.andExpect(jsonPath("$.error.code",
-            is(CTPException.Fault.SYSTEM_ERROR.name())));
+        is(CTPException.Fault.SYSTEM_ERROR.name())));
     actions.andExpect(jsonPath("$.error.message",
-            is(OUR_EXCEPTION_MESSAGE)));
+        is(OUR_EXCEPTION_MESSAGE)));
     actions.andExpect(jsonPath("$.error.timestamp",
-            isA(String.class)));
+        isA(String.class)));
+  }
+
+
+  /**
+   * Test available case group transitions are found by collection exercise Id and RU ref
+   *
+   * @throws Exception exception thrown
+   */
+  @Test
+  public void givenCollexIdAndRuRefWhenRequestForCaseGroupTransitionsThenAvailableCaseGroupTransitionsReturned() throws Exception {
+    // Given
+    CaseGroup result = CaseGroup.builder()
+        .id(CASE_GROUP_UUID)
+        .collectionExerciseId(CASE_GROUP_CE_ID)
+        .partyId(CASE_GROUP_PARTY_ID)
+        .sampleUnitRef(CASE_GROUP_SU_REF)
+        .sampleUnitType(CASE_GROUP_SU_TYPE)
+        .status(CaseGroupStatus.NOTSTARTED).build();
+
+    when(caseGroupService.findCaseGroupByCollectionExerciseIdAndRuRef(CASE_GROUP_CE_ID, CASE_GROUP_SU_REF)).thenReturn(result);
+
+    // When
+    ResultActions actions = mockMvc.perform(getJson(
+        String.format("/casegroups/transitions/%s/%s", CASE_GROUP_CE_ID, CASE_GROUP_SU_REF)));
+
+    // Then
+    actions.andExpect(status().isOk());
+
+    String availableTransitionsString = actions.andReturn().getResponse().getContentAsString();
+    Map<CategoryDTO.CategoryName, CaseGroupStatus> availableTransitions = new ObjectMapper()
+        .readValue(availableTransitionsString, new TypeReference<Map<CategoryDTO.CategoryName, CaseGroupStatus>>() {});
+    assertThat(availableTransitions, hasEntry(CategoryDTO.CategoryName.COLLECTION_INSTRUMENT_DOWNLOADED, CaseGroupStatus.INPROGRESS));
+    assertThat(availableTransitions, hasEntry(CategoryDTO.CategoryName.SUCCESSFUL_RESPONSE_UPLOAD, CaseGroupStatus.COMPLETE));
+    assertThat(availableTransitions, hasEntry(CategoryDTO.CategoryName.COMPLETED_BY_PHONE, CaseGroupStatus.COMPLETEDBYPHONE));
+  }
+
+  /**
+   * Test available case group transitions not found
+   *
+   * @throws Exception exception thrown
+   */
+  @Test
+  public void givenInvalidCollexIdAndRuRefWhenRequestForCaseGroupTransitionsThenCaseGroupNotFound() throws Exception {
+    // Given
+    String nonExistentCollexId = UUID.randomUUID().toString();
+    String nonExistentRuRef = "11111111111";
+
+    // When
+    ResultActions actions = mockMvc.perform(getJson(
+        String.format("/casegroups/transitions/%s/%s", nonExistentCollexId, nonExistentRuRef)));
+
+    // Then
+    actions.andExpect(status().isNotFound());
+   }
+
+  /**
+   * Test case group status transition is successful
+   *
+   * @throws Exception exception thrown
+   */
+  @Test
+  public void givenCollexIdRuRefAndCaseEventWhenChangeCaseGroupStatusThenSuccess() throws Exception {
+    // Given
+    CaseGroup caseGroupResult = CaseGroup.builder()
+        .id(CASE_GROUP_UUID)
+        .collectionExerciseId(CASE_GROUP_CE_ID)
+        .partyId(CASE_GROUP_PARTY_ID)
+        .sampleUnitRef(CASE_GROUP_SU_REF)
+        .sampleUnitType(CASE_GROUP_SU_TYPE)
+        .status(CaseGroupStatus.NOTSTARTED).build();
+    when(caseGroupService.findCaseGroupByCollectionExerciseIdAndRuRef(CASE_GROUP_CE_ID, CASE_GROUP_SU_REF)).thenReturn(caseGroupResult);
+
+    CategoryDTO.CategoryName categoryName = CategoryDTO.CategoryName.COMPLETED_BY_PHONE;
+
+    // When
+    CaseGroupEvent caseGroupEvent = new CaseGroupEvent();
+    caseGroupEvent.setEvent("COMPLETED_BY_PHONE");
+    ResultActions actions = mockMvc.perform(putJson(
+        String.format("/casegroups/transitions/%s/%s", CASE_GROUP_CE_ID,
+            CASE_GROUP_SU_REF), new ObjectMapper().writeValueAsString(caseGroupEvent)));
+
+    // Then
+    actions.andExpect(status().isOk());
+    verify(caseGroupService).transitionCaseGroupStatus(caseGroupResult, categoryName, CASE_GROUP_PARTY_ID);
+  }
+
+  /**
+   * Test case group status transition not found
+   *
+   * @throws Exception exception thrown
+   */
+  @Test
+  public void givenInvalidCollexIdPartyIdAndRuRefWhenPutCaseGroupTransitionThenCaseGroupTransitionNotFound() throws Exception {
+    // Given
+    String nonExistentCollexId = UUID.randomUUID().toString();
+    String nonExistentPartyId = UUID.randomUUID().toString();
+    String nonExistentRuRef = "11111111111";
+    CategoryDTO.CategoryName categoryName = CategoryDTO.CategoryName.COMPLETED_BY_PHONE;
+
+    // When
+    ResultActions actions = mockMvc.perform(putJson(
+        String.format("/casegroups/transitions/%s/%s/%s/%s", nonExistentCollexId, nonExistentPartyId,
+            nonExistentRuRef, categoryName), ""));
+
+    // Then
+    actions.andExpect(status().isNotFound());
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseGroupEndpointUnitTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseGroupEndpointUnitTest.java
@@ -262,7 +262,6 @@ public final class CaseGroupEndpointUnitTest {
         when(caseService.findCasesByCaseGroupFK(caseGroupResult.getCaseGroupPK())).thenReturn(Collections.singletonList(aCase));
         when(categoryService.findCategory(CategoryDTO.CategoryName.COMPLETED_BY_PHONE)).thenReturn(Category.builder().build());
 
-        CategoryDTO.CategoryName categoryName = CategoryDTO.CategoryName.COMPLETED_BY_PHONE;
         CaseGroupEvent caseGroupEvent = new CaseGroupEvent();
         caseGroupEvent.setEvent("COMPLETED_BY_PHONE");
 

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseGroupServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseGroupServiceImplTest.java
@@ -1,0 +1,78 @@
+package uk.gov.ons.ctp.response.casesvc.service.impl;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.ons.ctp.common.state.StateTransitionManager;
+import uk.gov.ons.ctp.response.casesvc.domain.model.CaseGroup;
+import uk.gov.ons.ctp.response.casesvc.domain.repository.CaseGroupRepository;
+import uk.gov.ons.ctp.response.casesvc.representation.CaseGroupStatus;
+import uk.gov.ons.ctp.response.casesvc.representation.CategoryDTO;
+import uk.gov.ons.ctp.response.casesvc.service.CaseGroupAuditService;
+
+import java.util.UUID;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class CaseGroupServiceImplTest {
+
+  @InjectMocks
+  private CaseGroupServiceImpl caseGroupService;
+
+  @Mock
+  private CaseGroupRepository caseGroupRepo;
+
+  @Mock
+  private StateTransitionManager<CaseGroupStatus, CategoryDTO.CategoryName> caseGroupStatusTransitionManager;
+
+  @Mock
+  private CaseGroupAuditService caseGroupAuditService;
+
+  @Test
+  public void givenCaseGroupStatusWhenCaseGroupStatusTransitionedThenTransitionIsSaved() throws Exception {
+    // Given
+    CaseGroup caseGroup = CaseGroup.builder()
+        .id(UUID.randomUUID())
+        .collectionExerciseId(UUID.randomUUID())
+        .partyId(UUID.randomUUID())
+        .sampleUnitRef("12345")
+        .sampleUnitType("B")
+        .status(CaseGroupStatus.NOTSTARTED).build();
+
+    CategoryDTO.CategoryName categoryName = CategoryDTO.CategoryName.COLLECTION_INSTRUMENT_DOWNLOADED;
+    given(caseGroupStatusTransitionManager.transition(caseGroup.getStatus(), categoryName)).willReturn(CaseGroupStatus.COMPLETE);
+
+    // When
+    caseGroupService.transitionCaseGroupStatus(caseGroup, categoryName, caseGroup.getPartyId());
+
+    // Then
+    verify(caseGroupRepo).saveAndFlush(caseGroup);
+  }
+
+  @Test
+  public void givenCaseGroupStatusWhenCaseGroupStatusTransitionedThenTransitionIsAudited() throws Exception {
+    // Given
+    CaseGroup caseGroup = CaseGroup.builder()
+        .id(UUID.randomUUID())
+        .collectionExerciseId(UUID.randomUUID())
+        .partyId(UUID.randomUUID())
+        .sampleUnitRef("12345")
+        .sampleUnitType("B")
+        .status(CaseGroupStatus.NOTSTARTED).build();
+
+    CategoryDTO.CategoryName categoryName = CategoryDTO.CategoryName.COLLECTION_INSTRUMENT_DOWNLOADED;
+    given(caseGroupStatusTransitionManager.transition(caseGroup.getStatus(), categoryName)).willReturn(CaseGroupStatus.COMPLETE);
+
+    // When
+    caseGroupService.transitionCaseGroupStatus(caseGroup, categoryName, caseGroup.getPartyId());
+
+    // Then
+    verify(caseGroupAuditService).updateAuditTable(caseGroup, caseGroup.getPartyId());
+  }
+
+}

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImplTest.java
@@ -27,10 +27,7 @@ import uk.gov.ons.ctp.response.casesvc.representation.CaseDTO;
 import uk.gov.ons.ctp.response.casesvc.representation.CaseGroupStatus;
 import uk.gov.ons.ctp.response.casesvc.representation.CaseState;
 import uk.gov.ons.ctp.response.casesvc.representation.CategoryDTO;
-import uk.gov.ons.ctp.response.casesvc.service.ActionSvcClientService;
-import uk.gov.ons.ctp.response.casesvc.service.CaseGroupAuditService;
-import uk.gov.ons.ctp.response.casesvc.service.CollectionExerciseSvcClientService;
-import uk.gov.ons.ctp.response.casesvc.service.InternetAccessCodeSvcClientService;
+import uk.gov.ons.ctp.response.casesvc.service.*;
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO;
 
 import java.sql.Timestamp;
@@ -43,6 +40,7 @@ import static junit.framework.TestCase.fail;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -65,7 +63,6 @@ public class CaseServiceImplTest {
   private static final String IAC_SVC_PUT_PATH = "iacs/123";
   private static final String IAC_SVC_POST_PATH = "iacs/123";
 
-//  private static final int CAT_ACCESSIBILITY_MATERIALS = 0;
   private static final int CAT_ACTION_CANCELLATION_COMPLETED = 1;
   private static final int CAT_ACTION_CANCELLATION_CREATED = 2;
   private static final int CAT_ACTION_COMPLETED = 3;
@@ -73,42 +70,17 @@ public class CaseServiceImplTest {
   private static final int CAT_ACTION_UPDATED = 5;
   private static final int CAT_ADDRESS_DETAILS_INCORRECT = 6;
   private static final int CAT_CASE_CREATED = 7;
-//  private static final int CAT_CLASSIFICATION_INCORRECT = 8;
-//  private static final int CAT_CLOSE_ESCALATION = 9;
-//  private static final int CAT_FIELD_COMPLAINT_ESCALATED = 10;
-//  private static final int CAT_FIELD_EMERGENCY_ESCALATED = 11;
   private static final int CAT_GENERAL_COMPLAINT = 12;
-//  private static final int CAT_GENERAL_COMPLAINT_ESCALATED = 13;
-//  private static final int CAT_GENERAL_ENQUIRY = 14;
-//  private static final int CAT_GENERAL_ENQUIRY_ESCALATED = 15;
   private static final int CAT_HOUSEHOLD_PAPER_REQUESTED = 16;
   private static final int CAT_HOUSEHOLD_REPLACEMENT_IAC_REQUESTED = 17;
-//  private static final int CAT_INCORRECT_ESCALATION = 18;
   private static final int CAT_H_INDIVIDUAL_PAPER_REQUESTED = 19;
   private static final int CAT_H_INDIVIDUAL_REPLACEMENT_IAC_REQUESTED = 20;
   private static final int CAT_H_INDIVIDUAL_RESPONSE_REQUESTED = 21;
-//  private static final int CAT_MISCELLANEOUS = 22;
   private static final int CAT_ONLINE_QUESTIONNAIRE_RESPONSE = 23;
   private static final int CAT_PAPER_QUESTIONNAIRE_RESPONSE = 24;
-//  private static final int CAT_PENDING = 25;
   private static final int CAT_REFUSAL = 26;
   private static final int CAT_RESPONDENT_ENROLED = 27;
-//  private static final int CAT_TECHNICAL_QUERY = 28;
   private static final int CAT_TRANSLATION_ARABIC = 29;
-//  private static final int CAT_TRANSLATION_BENGALI = 30;
-//  private static final int CAT_TRANSLATION_CANTONESE = 31;
-//  private static final int CAT_TRANSLATION_GUJARATI = 32;
-//  private static final int CAT_TRANSLATION_LITHUANIAN = 33;
-//  private static final int CAT_TRANSLATION_MANDARIN = 34;
-//  private static final int CAT_TRANSLATION_POLISH = 35;
-//  private static final int CAT_TRANSLATION_PORTUGUESE = 36;
-//  private static final int CAT_TRANSLATION_PUNJABI_GURMUKHI = 37;
-//  private static final int CAT_TRANSLATION_PUNJABI_SHAHMUKI = 38;
-//  private static final int CAT_TRANSLATION_SOMALI = 39;
-//  private static final int CAT_TRANSLATION_SPANISH = 40;
-//  private static final int CAT_TRANSLATION_TURKISH = 41;
-//  private static final int CAT_TRANSLATION_URDU = 42;
-//  private static final int CAT_UNDELIVERABLE = 43;
   private static final int CAT_RESPONDENT_ACCOUNT_CREATED = 44;
   private static final int CAT_ACCESS_CODE_AUTHENTICATION_ATTEMPT = 45;
   private static final int CAT_COLLECTION_INSTRUMENT_DOWNLOADED = 46;
@@ -154,6 +126,9 @@ public class CaseServiceImplTest {
   private CaseGroupRepository caseGroupRepo;
 
   @Mock
+  private CaseGroupService caseGroupService;
+
+  @Mock
   private AppConfig appConfig;
 
   @Mock
@@ -170,9 +145,6 @@ public class CaseServiceImplTest {
 
   @Mock
   private StateTransitionManager<CaseState, CaseDTO.CaseEvent> caseSvcStateTransitionManager;
-
-  @Mock
-  private StateTransitionManager<CaseGroupStatus, CategoryDTO.CategoryName> caseGroupStatusTransitionManager;
 
   @Mock
   private CaseGroupAuditService caseGroupAuditService;
@@ -601,11 +573,6 @@ public class CaseServiceImplTest {
     when(categoryRepo.findOne(CategoryDTO.CategoryName.REFUSAL)).thenReturn(categories.get(CAT_REFUSAL));
     when(categoryRepo.findOne(CategoryDTO.CategoryName.ONLINE_QUESTIONNAIRE_RESPONSE)).thenReturn(categories.
             get(CAT_ONLINE_QUESTIONNAIRE_RESPONSE));
-    when(caseGroupStatusTransitionManager.transition(CaseGroupStatus.NOTSTARTED,
-            CategoryDTO.CategoryName.REFUSAL)).thenThrow(new CTPException(CTPException.Fault.BAD_REQUEST));
-    when(caseGroupStatusTransitionManager.transition(CaseGroupStatus.NOTSTARTED,
-            CategoryDTO.CategoryName.ONLINE_QUESTIONNAIRE_RESPONSE))
-            .thenThrow(new CTPException(CTPException.Fault.BAD_REQUEST));
 
     CaseEvent refusalCaseEvent = fabricateEvent(CategoryDTO.CategoryName.REFUSAL, ACTIONABLE_H_INDIVIDUAL_CASE_FK);
     caseService.createCaseEvent(refusalCaseEvent, null);
@@ -837,85 +804,24 @@ public class CaseServiceImplTest {
   }
 
   @Test
-  public void testCaseGroupStatusUpdatedToComplete() throws Exception {
+  public void testCaseGroupStatusIsTransitioned() throws Exception {
+    Case targetCase = cases.get(ACTIONABLE_BI_CASE_FK);
+    CaseGroup caseGroup = caseGroups.get(1);
+
     when(caseRepo.findOne(ACTIONABLE_BI_CASE_FK)).thenReturn(
             cases.get(ACTIONABLE_BI_CASE_FK));
-    when(caseGroupRepo.findById(cases.get(ACTIONABLE_BI_CASE_FK).getCaseGroupId())).thenReturn(caseGroups.get(0));
-    when(categoryRepo.findOne(CategoryDTO.CategoryName.COLLECTION_INSTRUMENT_DOWNLOADED)).thenReturn(
-            categories.get(CAT_COLLECTION_INSTRUMENT_DOWNLOADED));
+    when(caseGroupRepo.findOne(cases.get(ACTIONABLE_BI_CASE_FK).getCaseGroupFK())).thenReturn(caseGroup);
     when(categoryRepo.findOne(CategoryDTO.CategoryName.SUCCESSFUL_RESPONSE_UPLOAD)).thenReturn(
             categories.get(CAT_SUCCESSFUL_RESPONSE_UPLOAD));
-    when(caseGroupStatusTransitionManager.transition(CaseGroupStatus.NOTSTARTED,
-            CategoryDTO.CategoryName.COLLECTION_INSTRUMENT_DOWNLOADED)).thenReturn(CaseGroupStatus.INPROGRESS);
-    when(caseGroupStatusTransitionManager.transition(CaseGroupStatus.INPROGRESS,
-            CategoryDTO.CategoryName.SUCCESSFUL_RESPONSE_UPLOAD)).thenReturn(CaseGroupStatus.COMPLETE);
-
-
-    CaseEvent caseEvent1 = fabricateEvent(CategoryDTO.CategoryName.COLLECTION_INSTRUMENT_DOWNLOADED,
-            ACTIONABLE_BI_CASE_FK);
-
-    caseService.createCaseEvent(caseEvent1, null);
-
-    CaseEvent caseEvent2 = fabricateEvent(CategoryDTO.CategoryName.SUCCESSFUL_RESPONSE_UPLOAD, ACTIONABLE_BI_CASE_FK);
-
-    caseService.createCaseEvent(caseEvent2, null);
-
-    ArgumentCaptor<CaseGroup> captor = ArgumentCaptor.forClass(CaseGroup.class);
-
-    CaseGroup initialUpdatedCaseGroup = caseGroups.get(0);
-    initialUpdatedCaseGroup.setStatus(CaseGroupStatus.INPROGRESS);
-
-    CaseGroup finalUpdatedCaseGroup = caseGroups.get(0);
-    finalUpdatedCaseGroup.setStatus(CaseGroupStatus.COMPLETE);
-
-    verify(caseGroupRepo, times(2)).saveAndFlush(captor.capture());
-    List<CaseGroup> caseGroupUpdates = captor.getAllValues();
-    assertEquals(caseGroupUpdates.get(0), initialUpdatedCaseGroup);
-    assertEquals(caseGroupUpdates.get(1), finalUpdatedCaseGroup);
-  }
-
-  @Test
-  public void testCaseGroupStatusUpdatedToInprogress() throws Exception {
-    when(caseRepo.findOne(ACTIONABLE_BI_CASE_FK)).thenReturn(
-            cases.get(ACTIONABLE_BI_CASE_FK));
-    when(caseGroupRepo.findById(cases.get(ACTIONABLE_BI_CASE_FK).getCaseGroupId())).thenReturn(caseGroups.get(1));
-    when(categoryRepo.findOne(CategoryDTO.CategoryName.COLLECTION_INSTRUMENT_DOWNLOADED)).thenReturn(
-            categories.get(CAT_COLLECTION_INSTRUMENT_DOWNLOADED));
-    when(caseGroupStatusTransitionManager.transition(CaseGroupStatus.NOTSTARTED,
-            CategoryDTO.CategoryName.COLLECTION_INSTRUMENT_DOWNLOADED)).thenReturn(CaseGroupStatus.INPROGRESS);
-
-
-    CaseEvent caseEvent1 = fabricateEvent(CategoryDTO.CategoryName.COLLECTION_INSTRUMENT_DOWNLOADED,
-            ACTIONABLE_BI_CASE_FK);
-
-    caseService.createCaseEvent(caseEvent1, null);
-
-    CaseGroup updatedCaseGroup = caseGroups.get(0);
-    updatedCaseGroup
-            .setStatus(CaseGroupStatus.INPROGRESS);
-    verify(caseGroupRepo, times(1)).saveAndFlush(updatedCaseGroup);
-  }
-
-  @Test
-  public void testCaseGroupStatusUpdatedToCompleteFromInprogress() throws Exception {
-    when(caseRepo.findOne(ACTIONABLE_BI_CASE_FK)).thenReturn(
-            cases.get(ACTIONABLE_BI_CASE_FK));
-    when(caseGroupRepo.findOne(cases.get(ACTIONABLE_BI_CASE_FK).getCaseGroupFK())).thenReturn(caseGroups.get(1));
-    when(categoryRepo.findOne(CategoryDTO.CategoryName.SUCCESSFUL_RESPONSE_UPLOAD)).thenReturn(
-            categories.get(CAT_SUCCESSFUL_RESPONSE_UPLOAD));
-    when(caseGroupStatusTransitionManager.transition(CaseGroupStatus.INPROGRESS,
-            CategoryDTO.CategoryName.SUCCESSFUL_RESPONSE_UPLOAD)).thenReturn(CaseGroupStatus.COMPLETE);
 
 
     CaseEvent caseEvent1 = fabricateEvent(CategoryDTO.CategoryName.SUCCESSFUL_RESPONSE_UPLOAD, ACTIONABLE_BI_CASE_FK);
 
     caseService.createCaseEvent(caseEvent1, null);
 
-    CaseGroup updatedCaseGroup = caseGroups.get(1);
-    updatedCaseGroup.setStatus(CaseGroupStatus.COMPLETE);
-    verify(caseGroupRepo, times(1)).saveAndFlush(updatedCaseGroup);
+    verify(caseGroupService, times(1)).transitionCaseGroupStatus(caseGroup,
+        CategoryDTO.CategoryName.SUCCESSFUL_RESPONSE_UPLOAD, targetCase.getPartyId());
   }
-
 
   @Test
   public void testCaseGroupStatusNotUpdated() throws Exception {
@@ -924,9 +830,6 @@ public class CaseServiceImplTest {
     when(caseGroupRepo.findOne(cases.get(ACTIONABLE_BI_CASE_FK).getCaseGroupFK())).thenReturn(caseGroups.get(1));
     when(categoryRepo.findOne(CategoryDTO.CategoryName.GENERAL_COMPLAINT)).thenReturn(
             categories.get(CAT_GENERAL_COMPLAINT));
-    when(caseGroupStatusTransitionManager.transition(CaseGroupStatus.INPROGRESS,
-            CategoryDTO.CategoryName.GENERAL_COMPLAINT))
-            .thenThrow(new CTPException(CTPException.Fault.BAD_REQUEST));
 
 
     CaseEvent caseEvent1 = fabricateEvent(CategoryDTO.CategoryName.GENERAL_COMPLAINT, ACTIONABLE_BI_CASE_FK);
@@ -944,9 +847,11 @@ public class CaseServiceImplTest {
    */
   @Test
   public void testEventActionCancellationCompleted() throws Exception {
-    when(caseRepo.findOne(ACTIONABLE_BI_CASE_FK)).thenReturn(cases.get(ACTIONABLE_BI_CASE_FK));
+    Case targetCase = cases.get(ACTIONABLE_BI_CASE_FK);
+    when(caseRepo.findOne(ACTIONABLE_BI_CASE_FK)).thenReturn(targetCase);
+    Category category = categories.get(CAT_ACTION_CANCELLATION_COMPLETED);
     when(categoryRepo.findOne(CategoryDTO.CategoryName.ACTION_CANCELLATION_COMPLETED)).
-            thenReturn(categories.get(CAT_ACTION_CANCELLATION_COMPLETED));
+            thenReturn(category);
 
     CaseEvent caseEvent = fabricateEvent(CategoryDTO.CategoryName.ACTION_CANCELLATION_COMPLETED,
             ACTIONABLE_BI_CASE_FK);
@@ -960,8 +865,8 @@ public class CaseServiceImplTest {
     verify(internetAccessCodeSvcClientService, never()).disableIAC(any(String.class));
     verify(caseSvcStateTransitionManager, never()).transition(any(CaseState.class),
             any(CaseDTO.CaseEvent.class));
-    verify(caseGroupStatusTransitionManager, times(1)).transition(CaseGroupStatus.NOTSTARTED,
-            CategoryDTO.CategoryName.ACTION_CANCELLATION_COMPLETED);
+    verify(caseGroupService, times(1)).transitionCaseGroupStatus(caseGroups.get(CASEGROUP_PK - 1),
+            CategoryDTO.CategoryName.ACTION_CANCELLATION_COMPLETED, targetCase.getPartyId());
     verify(notificationPublisher, never()).sendNotification(any(CaseNotification.class));
     verify(actionSvcClientService, never()).createAndPostAction(any(String.class), any(UUID.class),
             any(String.class));
@@ -1542,6 +1447,26 @@ public class CaseServiceImplTest {
     // no new action to be created
     verify(actionSvcClientService, times(0)).createAndPostAction(any(String.class),
             any(UUID.class), any(String.class));
+  }
+
+  /**
+   * caseService.createCaseEvent will be called with invalid state transitions
+   * but suppress the exception. This is expected behaviour. This code smells but keeping as is.
+   */
+  @Test
+  public void testGivenCaseGroupChangeIsInvalidWhenTransitionFailGracefully() throws Exception {
+    when(caseRepo.findOne(ACTIONABLE_BI_CASE_FK)).thenReturn(cases.get(ACTIONABLE_BI_CASE_FK));
+    Category successfulResponseUploadedCategory = categories.get(CAT_SUCCESSFUL_RESPONSE_UPLOAD);
+    when(categoryRepo.findOne(CategoryDTO.CategoryName.SUCCESSFUL_RESPONSE_UPLOAD)).thenReturn(
+            successfulResponseUploadedCategory);
+
+    doThrow(new CTPException(CTPException.Fault.BAD_REQUEST))
+            .when(caseGroupService).transitionCaseGroupStatus(any(), any(), any());
+    CaseEvent caseEvent = fabricateEvent(CategoryDTO.CategoryName.SUCCESSFUL_RESPONSE_UPLOAD, ACTIONABLE_BI_CASE_FK);
+
+    caseService.createCaseEvent(caseEvent, null);
+
+    verify(caseGroupService).transitionCaseGroupStatus(any(), any(), any());
   }
 
   /**

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/state/StateTransitionManagerUnitTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/state/StateTransitionManagerUnitTest.java
@@ -1,142 +1,181 @@
 package uk.gov.ons.ctp.response.casesvc.state;
 
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
+
+import org.junit.Test;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.common.state.StateTransitionManager;
-import uk.gov.ons.ctp.common.state.StateTransitionManagerFactory;
-import uk.gov.ons.ctp.response.casesvc.domain.model.CaseGroup;
-import uk.gov.ons.ctp.response.casesvc.representation.CaseDTO.CaseEvent;
+import uk.gov.ons.ctp.response.casesvc.representation.CaseDTO;
 import uk.gov.ons.ctp.response.casesvc.representation.CaseGroupStatus;
 import uk.gov.ons.ctp.response.casesvc.representation.CaseState;
 import uk.gov.ons.ctp.response.casesvc.representation.CategoryDTO;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-
-import static junit.framework.TestCase.fail;
 import static org.junit.Assert.assertEquals;
-import static uk.gov.ons.ctp.common.state.BasicStateTransitionManager.*;
 
-/**
- * A test of the state transition manager It simply has to test a single good
- * and a single bad transition - all it is testing is the underlying mechanism,
- * not a real implementation, where we will want to assert all of the valid and
- * invalid transitions
- *
- */
 public class StateTransitionManagerUnitTest {
 
-  private static final int TIMEOUT = 10000;
-  private static final int INVOCATIONS = 50;
-  private static final int THREAD_POOL_SIZE = 10;
-  private Map<CaseState, Map<CaseEvent, CaseState>> validCaseTransitions = new HashMap<>();
-  private Map<CaseGroupStatus, Map<CategoryDTO.CategoryName, CaseGroupStatus>> validCaseGroupTransitions = new HashMap<>();
+  private final CaseSvcStateTransitionManagerFactory factory = new CaseSvcStateTransitionManagerFactory();
+  @SuppressWarnings("unchecked")
+  private final StateTransitionManager<CaseState, CaseDTO.CaseEvent> caseStateMachine =
+          (StateTransitionManager<CaseState, CaseDTO.CaseEvent>) factory.getStateTransitionManager(CaseSvcStateTransitionManagerFactory.CASE_ENTITY);
+  @SuppressWarnings("unchecked")
+  private final StateTransitionManager<CaseGroupStatus, CategoryDTO.CategoryName> caseGroupStateMachine =
+          (StateTransitionManager<CaseGroupStatus, CategoryDTO.CategoryName>) factory.getStateTransitionManager(CaseSvcStateTransitionManagerFactory.CASE_GROUP);
 
-  /**
-   * Setup the transitions
-   */
-  @BeforeClass
-  public void setup() {
-    populateCaseTransitions();
-    populateCaseGroupStatusTransitions();
-  }
+  @Test
+  public void givenCaseStateSampledInitWhenActivatedThenActionable() throws CTPException {
+    // Given
+    CaseState sampledInit = CaseState.SAMPLED_INIT;
 
-  private void populateCaseTransitions() {
-    Map<CaseEvent, CaseState> sampledInitTransitions = new HashMap<>();
-    sampledInitTransitions.put(CaseEvent.ACTIVATED, CaseState.ACTIONABLE);
-    validCaseTransitions.put(CaseState.SAMPLED_INIT, sampledInitTransitions);
+    // When
+    CaseState destinationState = caseStateMachine.transition(sampledInit, CaseDTO.CaseEvent.ACTIVATED);
 
-    Map<CaseEvent, CaseState> replacementInitTransitions = new HashMap<>();
-    replacementInitTransitions.put(CaseEvent.REPLACED, CaseState.ACTIONABLE);
-    validCaseTransitions.put(CaseState.REPLACEMENT_INIT, replacementInitTransitions);
-
-    Map<CaseEvent, CaseState> actionableTransitions = new HashMap<>();
-    actionableTransitions.put(CaseEvent.ACCOUNT_CREATED, CaseState.ACTIONABLE);
-    actionableTransitions.put(CaseEvent.DEACTIVATED, CaseState.INACTIONABLE);
-    actionableTransitions.put(CaseEvent.DISABLED, CaseState.INACTIONABLE);
-    validCaseTransitions.put(CaseState.ACTIONABLE, actionableTransitions);
-
-    Map<CaseEvent, CaseState> inactionableTransitions = new HashMap<>();
-    inactionableTransitions.put(CaseEvent.DEACTIVATED, CaseState.INACTIONABLE);
-    inactionableTransitions.put(CaseEvent.DISABLED, CaseState.INACTIONABLE);
-    validCaseTransitions.put(CaseState.INACTIONABLE, inactionableTransitions);
-  }
-
-  private void populateCaseGroupStatusTransitions() {
-    //transitions from not started to in progress
-    Map<CategoryDTO.CategoryName, CaseGroupStatus> caseNotStartedTransitions = new HashMap<>();
-    caseNotStartedTransitions.put(CategoryDTO.CategoryName.COLLECTION_INSTRUMENT_DOWNLOADED, CaseGroupStatus.INPROGRESS);
-    caseNotStartedTransitions.put(CategoryDTO.CategoryName.SUCCESSFUL_RESPONSE_UPLOAD, CaseGroupStatus.COMPLETE);
-    validCaseGroupTransitions.put(CaseGroupStatus.NOTSTARTED, caseNotStartedTransitions);
-
-    //transitions from inprogress to completed
-    Map<CategoryDTO.CategoryName, CaseGroupStatus> caseInProgressTransitions = new HashMap<>();
-    caseInProgressTransitions.put(CategoryDTO.CategoryName.SUCCESSFUL_RESPONSE_UPLOAD, CaseGroupStatus.COMPLETE);
-    validCaseGroupTransitions.put(CaseGroupStatus.INPROGRESS, caseInProgressTransitions);
-
-  }
-
-  /**
-   * test a valid transition
-   */
-  @Test(threadPoolSize = THREAD_POOL_SIZE, invocationCount = INVOCATIONS, timeOut = TIMEOUT)
-  public void testCaseTransitions() {
-    StateTransitionManagerFactory stmFactory = new CaseSvcStateTransitionManagerFactory();
-    StateTransitionManager<CaseState, CaseEvent> stm = stmFactory.getStateTransitionManager(
-            CaseSvcStateTransitionManagerFactory.CASE_ENTITY);
-
-    validCaseTransitions.forEach((sourceState, transitions) -> {
-      transitions.forEach((caseEvent, caseState) -> {
-        try {
-          assertEquals(caseState, stm.transition(sourceState, caseEvent));
-        } catch (CTPException e) {
-          fail();
-        }
-      });
-
-      Arrays.asList(CaseEvent.values()).forEach(event -> {
-        if (!transitions.keySet().contains(event)) {
-          try {
-            stm.transition(sourceState, event);
-            fail();
-          } catch (CTPException ste) {
-            assertEquals(String.format(TRANSITION_ERROR_MSG, sourceState, event), ste.getMessage());
-          }
-        }
-      });
-    });
+    // Then
+    assertEquals(destinationState, CaseState.ACTIONABLE);
   }
 
   @Test
-  public void testCaseGroupTransitions() {
-    StateTransitionManagerFactory factory = new CaseSvcStateTransitionManagerFactory();
-    StateTransitionManager<CaseGroupStatus, CategoryDTO.CategoryName> caseGroupStageManager =
-            factory.getStateTransitionManager(CaseSvcStateTransitionManagerFactory.CASE_GROUP);
+  public void givenCaseStateReplacementInitWhenReplacedThenActionable() throws CTPException {
+    // Given
+    CaseState replacementInit = CaseState.REPLACEMENT_INIT;
 
-    validCaseGroupTransitions.forEach((currentState, transitions) -> {
-      transitions.forEach((caseEvent, caseState) ->{
-        try {
-          CaseGroupStatus newStatus = caseGroupStageManager.transition(currentState, caseEvent);
-          assertEquals(caseState, newStatus);
-        } catch (CTPException e) {
-          fail();
-        }
-      });
+    // When
+    CaseState destinationState = caseStateMachine.transition(replacementInit, CaseDTO.CaseEvent.REPLACED);
 
-      Arrays.asList(CategoryDTO.CategoryName.values()).forEach(event -> {
-        if(!transitions.keySet().contains(event)) {
-          try {
-            //invalid state transition should fail
-            CaseGroupStatus newStatus = caseGroupStageManager.transition(currentState, event);
-            fail();
-          } catch (CTPException ste) {
-            assertEquals(String.format(TRANSITION_ERROR_MSG, currentState, event), ste.getMessage());
-          }
-        }
-      });
-    });
+    // Then
+    assertEquals(destinationState, CaseState.ACTIONABLE);
   }
+
+  @Test
+  public void givenCaseStateActionableWhenDisabledThenInactionable() throws CTPException {
+    // Given
+    CaseState actionable = CaseState.ACTIONABLE;
+
+    // When
+    CaseState destinationState = caseStateMachine.transition(actionable, CaseDTO.CaseEvent.DISABLED);
+
+    // Then
+    assertEquals(destinationState, CaseState.INACTIONABLE);
+  }
+
+  @Test
+  public void givenCaseStateActionableWhenDeactivatedThenInactionable() throws CTPException {
+    // Given
+    CaseState actionable = CaseState.ACTIONABLE;
+
+    // When
+    CaseState destinationState = caseStateMachine.transition(actionable, CaseDTO.CaseEvent.DEACTIVATED);
+
+    // Then
+    assertEquals(destinationState, CaseState.INACTIONABLE);
+  }
+
+
+  @Test
+  public void givenCaseStateActionableWhenAccountCreatedThenActionable() throws CTPException {
+    // Given
+    CaseState actionable = CaseState.ACTIONABLE;
+
+    // When
+    CaseState destinationState = caseStateMachine.transition(actionable, CaseDTO.CaseEvent.ACCOUNT_CREATED);
+
+    // Then
+    assertEquals(destinationState, CaseState.ACTIONABLE);
+  }
+
+  @Test
+  public void givenCaseStateInactionableWhenDisabledThenInactionable() throws CTPException {
+    // Given
+    CaseState inactionable = CaseState.INACTIONABLE;
+
+    // When
+    CaseState destinationState = caseStateMachine.transition(inactionable, CaseDTO.CaseEvent.DISABLED);
+
+    // Then
+    assertEquals(destinationState, CaseState.INACTIONABLE);
+  }
+
+  @Test
+  public void givenCaseStateInactionableWhenDeactivatedThenInactionable() throws CTPException {
+    // Given
+    CaseState inactionable = CaseState.INACTIONABLE;
+
+    // When
+    CaseState destinationState = caseStateMachine.transition(inactionable, CaseDTO.CaseEvent.DEACTIVATED);
+
+    // Then
+    assertEquals(destinationState, CaseState.INACTIONABLE);
+  }
+
+  @Test
+  public void givenCaseGroupStateNotStartedWhenCIDownloadedThenInProgress() throws CTPException {
+    // Given
+    CaseGroupStatus notStarted = CaseGroupStatus.NOTSTARTED;
+
+    // When
+    CaseGroupStatus destinationState = caseGroupStateMachine.transition(notStarted, CategoryDTO.CategoryName.COLLECTION_INSTRUMENT_DOWNLOADED);
+
+    // Then
+    assertEquals(destinationState, CaseGroupStatus.INPROGRESS);
+  }
+
+  @Test
+  public void givenCaseGroupStateNotStartedWhenSuccessfulResponseUploadedThenComplete() throws CTPException {
+    // Given
+    CaseGroupStatus notStarted = CaseGroupStatus.NOTSTARTED;
+
+    // When
+    CaseGroupStatus destinationState = caseGroupStateMachine.transition(notStarted, CategoryDTO.CategoryName.SUCCESSFUL_RESPONSE_UPLOAD);
+
+    // Then
+    assertEquals(destinationState, CaseGroupStatus.COMPLETE);
+  }
+
+  @Test
+  public void givenCaseGroupStateNotStartedWhenCompletedByPhoneThenCompletedByPhone() throws CTPException {
+    // Given
+    CaseGroupStatus notStarted = CaseGroupStatus.NOTSTARTED;
+
+    // When
+    CaseGroupStatus destinationState = caseGroupStateMachine.transition(notStarted, CategoryDTO.CategoryName.COMPLETED_BY_PHONE);
+
+    // Then
+    assertEquals(destinationState, CaseGroupStatus.COMPLETEDBYPHONE);
+  }
+
+  @Test
+  public void givenCaseGroupStateInProgressWhenSuccessfulResponseUploadThenComplete() throws CTPException {
+    // Given
+    CaseGroupStatus inProgress = CaseGroupStatus.INPROGRESS;
+
+    // When
+    CaseGroupStatus destinationState = caseGroupStateMachine.transition(inProgress, CategoryDTO.CategoryName.SUCCESSFUL_RESPONSE_UPLOAD);
+
+    // Then
+    assertEquals(destinationState, CaseGroupStatus.COMPLETE);
+  }
+
+  @Test
+  public void givenCaseGroupStateInProgressWhenCompletedByPhoneThenCompletedByPhone() throws CTPException {
+    // Given
+    CaseGroupStatus inProgress = CaseGroupStatus.INPROGRESS;
+
+    // When
+    CaseGroupStatus destinationState = caseGroupStateMachine.transition(inProgress, CategoryDTO.CategoryName.COMPLETED_BY_PHONE);
+
+    // Then
+    assertEquals(destinationState, CaseGroupStatus.COMPLETEDBYPHONE);
+  }
+
+  @Test
+  public void givenCaseGroupStateReopenedWhenCompletedByPhoneThenCompletedByPhone() throws CTPException {
+    // Given
+    CaseGroupStatus reopened = CaseGroupStatus.REOPENED;
+
+    // When
+    CaseGroupStatus destinationState = caseGroupStateMachine.transition(reopened, CategoryDTO.CategoryName.COMPLETED_BY_PHONE);
+
+    // Then
+    assertEquals(destinationState, CaseGroupStatus.COMPLETEDBYPHONE);
+  }
+
 }


### PR DESCRIPTION
As a internal user (Survey administrator?)
I need to change the case response status to completed by phone for an RU for a specific CE for a specific survey
So that the respondent can complete the survey over the phone and they do not receive reminders

## Testing
1. Run up ras/rm
1. Run response-operations-ui on branch `us050-manually-change-the-response-status`
1. Run ras-backstage on branch `us050a-change-response-status`
1. Build repo `rm-common-service` branch `us050a-change-response-status-completedbyphone`
1. Build rm-casesvc-api on branch `us050a-change-response-status`
1. Run rm-case-service on branch `us050a-change-response-status-completedbyphone`
1. Load data with `make setup`
1. Open http://localhost:8085/reporting-units/49900000001
1. Click change
1. See updated status

[Trello](https://trello.com/c/q5skwt1o/91-us050a-int-manually-change-the-response-status-for-a-given-ru-survey-ce-to-completed-by-phone-xl)