### PR TITLE
Us051 generate new enrolment code

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpoint.java
@@ -22,6 +22,7 @@ import uk.gov.ons.ctp.response.casesvc.domain.model.Case;
 import uk.gov.ons.ctp.response.casesvc.domain.model.CaseEvent;
 import uk.gov.ons.ctp.response.casesvc.domain.model.CaseGroup;
 import uk.gov.ons.ctp.response.casesvc.domain.model.Category;
+import uk.gov.ons.ctp.response.casesvc.message.sampleunitnotification.SampleUnitBase;
 import uk.gov.ons.ctp.response.casesvc.representation.CaseDTO;
 import uk.gov.ons.ctp.response.casesvc.representation.CaseDetailsDTO;
 import uk.gov.ons.ctp.response.casesvc.representation.CaseEventCreationRequestDTO;
@@ -32,6 +33,7 @@ import uk.gov.ons.ctp.response.casesvc.representation.CreatedCaseEventDTO;
 import uk.gov.ons.ctp.response.casesvc.service.CaseGroupService;
 import uk.gov.ons.ctp.response.casesvc.service.CaseService;
 import uk.gov.ons.ctp.response.casesvc.service.CategoryService;
+import uk.gov.ons.ctp.response.casesvc.service.InternetAccessCodeSvcClientService;
 import uk.gov.ons.ctp.response.casesvc.utility.Constants;
 
 import javax.validation.Valid;
@@ -64,6 +66,9 @@ public final class CaseEndpoint implements CTPEndpoint {
 
   @Autowired
   private CaseService caseService;
+
+  @Autowired
+  private InternetAccessCodeSvcClientService internetAccessCodeSvcClientService;
 
   @Qualifier("caseSvcBeanMapper")
   @Autowired
@@ -149,6 +154,40 @@ public final class CaseEndpoint implements CTPEndpoint {
     createNewEventForAccessCodeAuthAttempt(caseObj);
 
     return ResponseEntity.ok(buildDetailedCaseDTO(caseObj, caseevents, iacFlag));
+  }
+
+  /**
+   * the POST endpoint to generate and return a new iac
+   *
+   * @param collectionexerciseid to generate iac for
+   * @param ruref to generate iac for
+   * @return the case created
+   * @throws CTPException something went wrong
+   */
+  @RequestMapping(value = "/iac/{collectionexerciseid}/{ruref}", method = RequestMethod.POST)
+  public ResponseEntity<CaseDetailsDTO> generateNewIac(@PathVariable("collectionexerciseid") final UUID collectionexerciseid,
+                                                       @PathVariable("ruref") final String ruref)
+          throws CTPException {
+    log.info("Entering generateNewIac with collectionexerciseid {} and ruref {}", collectionexerciseid, ruref);
+
+    CaseGroup caseGroup = caseGroupService.findCaseGroupByCollectionExerciseIdAndRuRef(collectionexerciseid, ruref);
+    if (caseGroup == null) {
+      throw new CTPException(CTPException.Fault.RESOURCE_NOT_FOUND,
+              String.format("CaseGroup not found for collectionexerciseid %s and ruref %s",
+                      collectionexerciseid, ruref));
+    }
+    List<Case> casesList = caseService.findCasesByCaseGroupFK(caseGroup.getCaseGroupPK());
+    Case latestCase = casesList.get(casesList.size() - 1);
+    List<String> iacs = internetAccessCodeSvcClientService.generateIACs(1);
+
+    SampleUnitBase sampleUnitBase = new SampleUnitBase(caseGroup.getSampleUnitRef(), Character.toString('B'),
+            caseGroup.getPartyId().toString(), latestCase.getCollectionInstrumentId().toString());
+    Case newCase = caseService.generateNewCase(sampleUnitBase, caseGroup, iacs.get(0), latestCase.getActionPlanId());
+    if (newCase == null) {
+      throw new CTPException(CTPException.Fault.RESOURCE_NOT_FOUND, "Failed to create new case");
+    }
+    log.info("Successfully created new case {}", newCase.getId());
+    return ResponseEntity.ok(buildDetailedCaseDTO(newCase, false, true));
   }
 
   /**

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpoint.java
@@ -183,9 +183,6 @@ public final class CaseEndpoint implements CTPEndpoint {
     SampleUnitBase sampleUnitBase = new SampleUnitBase(caseGroup.getSampleUnitRef(), Character.toString('B'),
             caseGroup.getPartyId().toString(), latestCase.getCollectionInstrumentId().toString());
     Case newCase = caseService.generateNewCase(sampleUnitBase, caseGroup, iacs.get(0), latestCase.getActionPlanId());
-    if (newCase == null) {
-      throw new CTPException(CTPException.Fault.RESOURCE_NOT_FOUND, "Failed to create new case");
-    }
     log.info("Successfully created new case {}", newCase.getId());
     return ResponseEntity.ok(buildDetailedCaseDTO(newCase, false, true));
   }

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/CaseService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/CaseService.java
@@ -4,7 +4,9 @@ import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.common.service.CTPService;
 import uk.gov.ons.ctp.response.casesvc.domain.model.Case;
 import uk.gov.ons.ctp.response.casesvc.domain.model.CaseEvent;
+import uk.gov.ons.ctp.response.casesvc.domain.model.CaseGroup;
 import uk.gov.ons.ctp.response.casesvc.message.notification.CaseNotification;
+import uk.gov.ons.ctp.response.casesvc.message.sampleunitnotification.SampleUnitBase;
 import uk.gov.ons.ctp.response.casesvc.message.sampleunitnotification.SampleUnitParent;
 import uk.gov.ons.ctp.response.casesvc.representation.CaseDTO;
 
@@ -128,4 +130,6 @@ public interface CaseService extends CTPService {
    * @param caseData the CaseCreation data
    */
   void createInitialCase(SampleUnitParent caseData);
+
+  Case generateNewCase(SampleUnitBase caseData, CaseGroup caseGroup, String iac, UUID actionplanid);
 }

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImpl.java
@@ -540,4 +540,14 @@ public class CaseServiceImpl implements CaseService {
 
     return newCase;
   }
+
+  @Override
+  public Case generateNewCase(SampleUnitBase caseData, CaseGroup caseGroup, String iac, UUID actionplanid) {
+    Case newCase = createNewCase(caseData, caseGroup);
+    newCase.setIac(iac);
+    newCase.setActionPlanId(actionplanid);
+    newCase.setState(CaseState.ACTIONABLE);
+    caseRepo.saveAndFlush(newCase);
+    return newCase;
+  }
 }

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpointUnitTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpointUnitTest.java
@@ -23,6 +23,7 @@ import uk.gov.ons.ctp.response.casesvc.domain.model.Case;
 import uk.gov.ons.ctp.response.casesvc.domain.model.CaseEvent;
 import uk.gov.ons.ctp.response.casesvc.domain.model.CaseGroup;
 import uk.gov.ons.ctp.response.casesvc.domain.model.Category;
+import uk.gov.ons.ctp.response.casesvc.message.sampleunitnotification.SampleUnitBase;
 import uk.gov.ons.ctp.response.casesvc.representation.CaseEventCreationRequestDTO;
 import uk.gov.ons.ctp.response.casesvc.representation.CaseGroupStatus;
 import uk.gov.ons.ctp.response.casesvc.representation.CaseState;
@@ -31,8 +32,10 @@ import uk.gov.ons.ctp.response.casesvc.representation.InboundChannel;
 import uk.gov.ons.ctp.response.casesvc.service.CaseGroupService;
 import uk.gov.ons.ctp.response.casesvc.service.CaseService;
 import uk.gov.ons.ctp.response.casesvc.service.CategoryService;
+import uk.gov.ons.ctp.response.casesvc.service.InternetAccessCodeSvcClientService;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
@@ -127,6 +130,7 @@ public final class CaseEndpointUnitTest {
   private static final String NINE = "9";
   private static final String OUR_EXCEPTION_MESSAGE = "this is what we throw";
   private static final String FINDCASEBYID = "findCaseById";
+  private static final List<String> IACList = Arrays.asList("jkbvyklkwj88");
 
   private static final String CASEEVENT_INVALIDJSON =
           "{\"description\":\"a\",\"category\":\"BAD_CAT\",\"createdBy\":\"u\"}";
@@ -147,6 +151,9 @@ public final class CaseEndpointUnitTest {
 
   @Mock
   private CaseGroupService caseGroupService;
+
+  @Mock
+  private InternetAccessCodeSvcClientService internetAccessCodeSvcClientService;
 
   @Spy
   private MapperFacade mapperFacade = new CaseSvcBeanMapper();
@@ -634,6 +641,63 @@ public final class CaseEndpointUnitTest {
    CaseEventCreationRequestDTO caseEventDTO = new CaseEventCreationRequestDTO();
    caseEndpoint.createCaseEvent(CASE1_ID, caseEventDTO, bindingResult);
   }
-  
-  
+
+  /**
+   * Tests if new code is generated from the endpoint
+   */
+  @Test
+  public void verifyGenerateNewIac() throws Exception {
+    when(caseGroupService.findCaseGroupByCollectionExerciseIdAndRuRef(any(), any())).thenReturn(caseGroupResults.get(0));
+    when(caseService.findCasesByCaseGroupFK(any())).thenReturn(caseResults);
+    when(internetAccessCodeSvcClientService.generateIACs(1)).thenReturn(IACList);
+    when(caseService.generateNewCase(any(), any(), any(), any())).thenReturn(caseResults.get(0));
+
+    String postUrl = String.format("/cases/iac/%s/%s", CASE1_CASEGROUP_COLLECTION_EXERCISE_ID, CASE1_CASEGROUP_SAMPLE_UNIT_REF);
+    ResultActions actions = mockMvc.perform(postJson(postUrl, ""));
+
+    actions.andExpect(status().isOk());
+    actions.andExpect(jsonPath("$.iac", is(caseResults.get(0).getIac())));
+  }
+
+  /**
+   * Tests if no caseGroup is found for ce_id and ru_ref that Exception is thrown
+   * @throws Exception exception thrown
+   */
+  @Test
+  public void verifyNoCaseGroupThrowsException() throws Exception {
+    when(caseGroupService.findCaseGroupByCollectionExerciseIdAndRuRef(any(), any())).thenReturn(null);
+
+    String postUrl = String.format("/cases/iac/%s/%s", CASE1_CASEGROUP_COLLECTION_EXERCISE_ID, CASE1_CASEGROUP_SAMPLE_UNIT_REF);
+    ResultActions actions = mockMvc.perform(postJson(postUrl, ""));
+
+    actions.andExpect(status().isNotFound());
+    actions.andExpect(handler().handlerType(CaseEndpoint.class));
+    actions.andExpect(handler().methodName("generateNewIac"));
+    actions.andExpect(jsonPath("$.error.code",
+            is(CTPException.Fault.RESOURCE_NOT_FOUND.name())));
+    actions.andExpect(jsonPath("$.error.timestamp",
+            isA(String.class)));
+  }
+
+  /**
+   * Tests if new code is generated from the endpoint
+   */
+  @Test
+  public void verifyNoNewCaseCaseThrowsException() throws Exception {
+    when(caseGroupService.findCaseGroupByCollectionExerciseIdAndRuRef(any(), any())).thenReturn(caseGroupResults.get(0));
+    when(caseService.findCasesByCaseGroupFK(any())).thenReturn(caseResults);
+    when(internetAccessCodeSvcClientService.generateIACs(1)).thenReturn(IACList);
+    when(caseService.generateNewCase(any(), any(), any(), any())).thenReturn(null);
+
+    String postUrl = String.format("/cases/iac/%s/%s", CASE1_CASEGROUP_COLLECTION_EXERCISE_ID, CASE1_CASEGROUP_SAMPLE_UNIT_REF);
+    ResultActions actions = mockMvc.perform(postJson(postUrl, ""));
+
+    actions.andExpect(status().isNotFound());
+    actions.andExpect(handler().handlerType(CaseEndpoint.class));
+    actions.andExpect(handler().methodName("generateNewIac"));
+    actions.andExpect(jsonPath("$.error.code",
+            is(CTPException.Fault.RESOURCE_NOT_FOUND.name())));
+    actions.andExpect(jsonPath("$.error.timestamp",
+            isA(String.class)));
+  }
 }

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpointUnitTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpointUnitTest.java
@@ -678,26 +678,4 @@ public final class CaseEndpointUnitTest {
     actions.andExpect(jsonPath("$.error.timestamp",
             isA(String.class)));
   }
-
-  /**
-   * Tests if new code is generated from the endpoint
-   */
-  @Test
-  public void verifyNoNewCaseCaseThrowsException() throws Exception {
-    when(caseGroupService.findCaseGroupByCollectionExerciseIdAndRuRef(any(), any())).thenReturn(caseGroupResults.get(0));
-    when(caseService.findCasesByCaseGroupFK(any())).thenReturn(caseResults);
-    when(internetAccessCodeSvcClientService.generateIACs(1)).thenReturn(IACList);
-    when(caseService.generateNewCase(any(), any(), any(), any())).thenReturn(null);
-
-    String postUrl = String.format("/cases/iac/%s/%s", CASE1_CASEGROUP_COLLECTION_EXERCISE_ID, CASE1_CASEGROUP_SAMPLE_UNIT_REF);
-    ResultActions actions = mockMvc.perform(postJson(postUrl, ""));
-
-    actions.andExpect(status().isNotFound());
-    actions.andExpect(handler().handlerType(CaseEndpoint.class));
-    actions.andExpect(handler().methodName("generateNewIac"));
-    actions.andExpect(jsonPath("$.error.code",
-            is(CTPException.Fault.RESOURCE_NOT_FOUND.name())));
-    actions.andExpect(jsonPath("$.error.timestamp",
-            isA(String.class)));
-  }
 }


### PR DESCRIPTION
Added new endpoint which creates a new case with a new enrolment code for a given collection_exercise_id and ru_ref

To test, run with other PR's
[response-operations-ui](https://github.com/ONSdigital/response-operations-ui/pull/85)
[ras-backstage-service](https://github.com/ONSdigital/ras-backstage/pull/71)
[rasrm-acceptance-tests](https://github.com/ONSdigital/rasrm-acceptance-tests/pull/68)

[Trello](https://trello.com/c/FIBrMsOb/72-us051-int-generate-a-new-additional-enrolment-code-l-25pts-5d)
[Confluence](https://digitaleq.atlassian.net/wiki/spaces/RASB/pages/227115065/US051+Provide+a+new+Enrollment+Code+to+an+RU+for+a+specific+survey+over+the+phone+Large)