### PR TITLE
Update related Bi cases when SUCCESSFUL_RESPONSE_UPLOAD event

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImpl.java
@@ -194,7 +194,7 @@ public class CaseServiceImpl implements CaseService {
       transitionCaseGroupStatus(targetCase, caseEvent);
 
       // if this is a respondent enrolling event
-      if (caseEvent.getCategory().toString().equals("RESPONDENT_ENROLED")) {
+      if (caseEvent.getCategory().equals(CategoryDTO.CategoryName.RESPONDENT_ENROLED)) {
         // are there other case groups that need updating
         List<CaseGroup> caseGroups = caseGroupService.transitionOtherCaseGroups(targetCase);
         checkCaseState(category, caseGroups, caseEvent, newCase);
@@ -204,7 +204,8 @@ public class CaseServiceImpl implements CaseService {
         // should a new case be created?
         createNewCase(category, caseEvent, targetCase, newCase);
 
-        if (caseEvent.getCategory().toString().equals("SUCCESSFUL_RESPONSE_UPLOAD")) {
+        if (caseEvent.getCategory().equals(CategoryDTO.CategoryName.SUCCESSFUL_RESPONSE_UPLOAD) ||
+                caseEvent.getCategory().equals(CategoryDTO.CategoryName.COMPLETED_BY_PHONE)) {
           //Update state of all BI's so they don't receive comms
           updateAllAssociatedBiCases(targetCase, category);
         } else {

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImpl.java
@@ -191,31 +191,59 @@ public class CaseServiceImpl implements CaseService {
       // should we create an ad hoc action?
       createAdHocAction(category, caseEvent);
 
-      // transition case group status
-      CaseGroup caseGroup = caseGroupRepo.findOne(targetCase.getCaseGroupFK());
-      try {
-        caseGroupService.transitionCaseGroupStatus(caseGroup, caseEvent.getCategory(), targetCase.getPartyId());
-      } catch (CTPException e) {
-        //The transition manager throws an exception if the event doesn't cause a transition, however there are lots of
-        // events which do not cause CaseGroupStatus transitions, (this is valid behaviour).
-        log.debug(e.getMessage());
-      }
+      transitionCaseGroupStatus(targetCase, caseEvent);
 
       // if this is a respondent enrolling event
       if (caseEvent.getCategory().toString().equals("RESPONDENT_ENROLED")) {
         // are there other case groups that need updating
         List<CaseGroup> caseGroups = caseGroupService.transitionOtherCaseGroups(targetCase);
         checkCaseState(category, caseGroups, caseEvent, newCase);
+
       } else {
+
         // should a new case be created?
         createNewCase(category, caseEvent, targetCase, newCase);
-        effectTargetCaseStateTransition(category, targetCase);
+
+        if (caseEvent.getCategory().toString().equals("SUCCESSFUL_RESPONSE_UPLOAD")) {
+          //Update state of all BI's so they don't receive comms
+          updateAllAssociatedBiCases(targetCase, category);
+        } else {
+          effectTargetCaseStateTransition(category, targetCase);
+        }
+
       }
+
     }
 
     return createdCaseEvent;
   }
 
+  /**
+   * If BI case is transitioned to Inactionable transition all other BI Cases associated with the B case,
+   * they should all be inactionable after a successful upload & not receive any reminder communications.
+   * @param targetCase
+   * @param category
+   * @throws CTPException
+   */
+  private void updateAllAssociatedBiCases (final Case targetCase, final Category category) throws CTPException  {
+    UUID caseGroupId = targetCase.getCaseGroupId();
+    List<Case> associatedBiCases = caseRepo.findByCaseGroupId(caseGroupId);
+
+    for (Case caze : associatedBiCases) {
+      effectTargetCaseStateTransition(category, caze);
+    }
+  }
+
+  private void transitionCaseGroupStatus(final Case targetCase, final CaseEvent caseEvent) {
+    CaseGroup caseGroup = caseGroupRepo.findOne(targetCase.getCaseGroupFK());
+    try {
+      caseGroupService.transitionCaseGroupStatus(caseGroup, caseEvent.getCategory(), targetCase.getPartyId());
+    } catch (CTPException e) {
+      //The transition manager throws an exception if the event doesn't cause a transition, however there are lots of
+      // events which do not cause CaseGroupStatus transitions, (this is valid behaviour).
+      log.debug(e.getMessage());
+    }
+  }
   /**
    * This has been triggered by a 'RESPONDENT_ENROLED' event. If we find any associated Case Groups
    * with only B cases we need to make case 'INACTIONABLE' and create BI case.

--- a/src/test/resources/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImplTest.Case.json
+++ b/src/test/resources/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImplTest.Case.json
@@ -192,5 +192,18 @@
 		"iac": "kkkk llll mmmm",
 		"actionPlanId": "4381731e-e386-41a1-8462-26373744db81",
 		"responses": []
+	},
+	{
+		"id": "91fda7f2-3825-4bd4-baef-943a0ccf0858",
+		"casePK": 13,
+		"caseGroupFK":1,
+		"state": "ACTIONABLE",
+		"sampleUnitType": "BI",
+		"partyId": "3b136c4b-7a14-4904-9e01-13364dd7b972",
+		"createdDateTime": 1460732606544,
+		"createdBy": "me",
+		"iac": "",
+		"actionPlanId": "4381731e-e386-41a1-8462-26373744db81",
+		"responses": []
 	}
 ]


### PR DESCRIPTION
Defect 17.6, if a business had multiple enrolled respondents, when one of them completes the survey the other BI Cases are not removed from the action service and then receive reminders when they shouldn't.