### PR TITLE
Us022 disable respondent enrolment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.product</groupId>
       <artifactId>casesvc-api</artifactId>
-      <version>10.49.11-SNAPSHOT</version>
+      <version>10.49.11</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.product</groupId>
       <artifactId>casesvc-api</artifactId>
-      <version>10.49.7</version>
+      <version>10.49.11-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/domain/repository/CaseRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/domain/repository/CaseRepository.java
@@ -43,6 +43,14 @@ public interface CaseRepository extends JpaRepository<Case, Integer> {
   List<Case> findByCaseGroupId(UUID caseGroupFK);
 
   /**
+   * Find cases assigned to the given casegroupid in a given state
+   * @param caseGroupFK the case group UUID
+   * @param state the case group state
+   * @return the cases in the group
+   */
+  List<Case> findByCaseGroupIdAndState(UUID caseGroupFK, CaseState state);
+
+  /**
    * Find cases assigned to the given iac
    * There should only be one - it is the job of the caller to complain if there is >1
    * @param iac the iac

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImpl.java
@@ -199,12 +199,11 @@ public class CaseServiceImpl implements CaseService {
         checkCaseState(category, caseGroups, caseEvent, newCase);
       }
 
-      else if (caseEvent.getCategory().equals(CategoryDTO.CategoryName.SUCCESSFUL_RESPONSE_UPLOAD) ||
-                 caseEvent.getCategory().equals(CategoryDTO.CategoryName.COMPLETED_BY_PHONE)) {
+      else if (caseEvent.getCategory().equals(CategoryDTO.CategoryName.SUCCESSFUL_RESPONSE_UPLOAD)
+               || caseEvent.getCategory().equals(CategoryDTO.CategoryName.COMPLETED_BY_PHONE)) {
         createNewCase(category, caseEvent, targetCase, newCase);
         updateAllAssociatedBiCases(targetCase, category);
       }
-
       else if (caseEvent.getCategory().equals(CategoryDTO.CategoryName.DISABLE_RESPONDENT_ENROLMENT)) {
         effectTargetCaseStateTransition(category, targetCase);
         List<Case> actionableCases = caseRepo.findByCaseGroupIdAndState(
@@ -212,12 +211,12 @@ public class CaseServiceImpl implements CaseService {
         CaseGroup caseGroup = caseGroupRepo.findById(targetCase.getCaseGroupId());
 
         // Create a new case if no actionable case remain and casegroup is not in a complete state
-        if (actionableCases.isEmpty() && (!caseGroup.getStatus().equals(CaseGroupStatus.COMPLETE) &&
-                                          !caseGroup.getStatus().equals(CaseGroupStatus.COMPLETEDBYPHONE))) {
+        if (actionableCases.isEmpty()
+            && !caseGroup.getStatus().equals(CaseGroupStatus.COMPLETE)
+            && !caseGroup.getStatus().equals(CaseGroupStatus.COMPLETEDBYPHONE)) {
           createNewCase(category, caseEvent, targetCase, newCase);
         }
       }
-
       else {
         createNewCase(category, caseEvent, targetCase, newCase);
         effectTargetCaseStateTransition(category, targetCase);

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImpl.java
@@ -201,7 +201,6 @@ public class CaseServiceImpl implements CaseService {
 
       else if (caseEvent.getCategory().equals(CategoryDTO.CategoryName.SUCCESSFUL_RESPONSE_UPLOAD) ||
                  caseEvent.getCategory().equals(CategoryDTO.CategoryName.COMPLETED_BY_PHONE)) {
-        // should a new case be created?
         createNewCase(category, caseEvent, targetCase, newCase);
         updateAllAssociatedBiCases(targetCase, category);
       }
@@ -211,6 +210,8 @@ public class CaseServiceImpl implements CaseService {
         List<Case> actionableCases = caseRepo.findByCaseGroupIdAndState(
                 targetCase.getCaseGroupId(), CaseState.ACTIONABLE);
         CaseGroup caseGroup = caseGroupRepo.findById(targetCase.getCaseGroupId());
+
+        // Create a new case if no actionable case remain and casegroup is not in a complete state
         if (actionableCases.isEmpty() && (!caseGroup.getStatus().equals(CaseGroupStatus.COMPLETE) &&
                                           !caseGroup.getStatus().equals(CaseGroupStatus.COMPLETEDBYPHONE))) {
           createNewCase(category, caseEvent, targetCase, newCase);
@@ -218,7 +219,6 @@ public class CaseServiceImpl implements CaseService {
       }
 
       else {
-        // should a new case be created?
         createNewCase(category, caseEvent, targetCase, newCase);
         effectTargetCaseStateTransition(category, targetCase);
       }

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImpl.java
@@ -210,7 +210,9 @@ public class CaseServiceImpl implements CaseService {
         effectTargetCaseStateTransition(category, targetCase);
         List<Case> actionableCases = caseRepo.findByCaseGroupIdAndState(
                 targetCase.getCaseGroupId(), CaseState.ACTIONABLE);
-        if (actionableCases.isEmpty()) {
+        CaseGroup caseGroup = caseGroupRepo.findById(targetCase.getCaseGroupId());
+        if (actionableCases.isEmpty() && (!caseGroup.getStatus().equals(CaseGroupStatus.COMPLETE) &&
+                                          !caseGroup.getStatus().equals(CaseGroupStatus.COMPLETEDBYPHONE))) {
           createNewCase(category, caseEvent, targetCase, newCase);
         }
       }

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImpl.java
@@ -204,6 +204,7 @@ public class CaseServiceImpl implements CaseService {
         createNewCase(category, caseEvent, targetCase, newCase);
         updateAllAssociatedBiCases(targetCase, category);
       }
+
       else if (caseEvent.getCategory().equals(CategoryDTO.CategoryName.DISABLE_RESPONDENT_ENROLMENT)) {
         effectTargetCaseStateTransition(category, targetCase);
         List<Case> actionableCases = caseRepo.findByCaseGroupIdAndState(
@@ -217,6 +218,7 @@ public class CaseServiceImpl implements CaseService {
           createNewCase(category, caseEvent, targetCase, newCase);
         }
       }
+
       else {
         createNewCase(category, caseEvent, targetCase, newCase);
         effectTargetCaseStateTransition(category, targetCase);

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/state/CaseSvcStateTransitionManagerFactory.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/state/CaseSvcStateTransitionManagerFactory.java
@@ -42,7 +42,6 @@ public class CaseSvcStateTransitionManagerFactory implements StateTransitionMana
     builder.put(CaseState.ACTIONABLE, CaseEvent.ACCOUNT_CREATED, CaseState.ACTIONABLE);
     builder.put(CaseState.ACTIONABLE, CaseEvent.DEACTIVATED, CaseState.INACTIONABLE);
     builder.put(CaseState.ACTIONABLE, CaseEvent.DISABLED, CaseState.INACTIONABLE);
-    builder.put(CaseState.ACTIONABLE, CaseEvent.DISABLE_RESPONDENT_ENROLMENT, CaseState.INACTIONABLE);
 
     // From inactionable on deactivated, disabled to inactionable
     builder.put(CaseState.INACTIONABLE, CaseEvent.DEACTIVATED, CaseState.INACTIONABLE);

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/state/CaseSvcStateTransitionManagerFactory.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/state/CaseSvcStateTransitionManagerFactory.java
@@ -42,6 +42,7 @@ public class CaseSvcStateTransitionManagerFactory implements StateTransitionMana
     builder.put(CaseState.ACTIONABLE, CaseEvent.ACCOUNT_CREATED, CaseState.ACTIONABLE);
     builder.put(CaseState.ACTIONABLE, CaseEvent.DEACTIVATED, CaseState.INACTIONABLE);
     builder.put(CaseState.ACTIONABLE, CaseEvent.DISABLED, CaseState.INACTIONABLE);
+    builder.put(CaseState.ACTIONABLE, CaseEvent.DISABLE_RESPONDENT_ENROLMENT, CaseState.INACTIONABLE);
 
     // From inactionable on deactivated, disabled to inactionable
     builder.put(CaseState.INACTIONABLE, CaseEvent.DEACTIVATED, CaseState.INACTIONABLE);

--- a/src/main/resources/database/changelog-master.yml
+++ b/src/main/resources/database/changelog-master.yml
@@ -38,3 +38,6 @@ databaseChangeLog:
 
   - include:
       file: database/changes/release-10.53.0/changelog.yml
+
+  - include:
+      file: database/changes/release-10.54.0/changelog.yml

--- a/src/main/resources/database/changes/release-10.54.0/add_disable_respondent_enrolment_category.sql
+++ b/src/main/resources/database/changes/release-10.54.0/add_disable_respondent_enrolment_category.sql
@@ -1,0 +1,2 @@
+INSERT INTO casesvc.category (categorypk, shortdescription, longdescription, eventtype, role, generatedactiontype, "group", oldcasesampleunittypes, newcasesampleunittype, recalccollectioninstrument)
+VALUES ('DISABLE_RESPONDENT_ENROLMENT', 'Disable Respondent Enrolment', 'Disable Respondent Enrolment', 'DISABLED',  NULL, NULL, NULL, 'BI', NULL, NULL);

--- a/src/main/resources/database/changes/release-10.54.0/add_disable_respondent_enrolment_category.sql
+++ b/src/main/resources/database/changes/release-10.54.0/add_disable_respondent_enrolment_category.sql
@@ -1,2 +1,2 @@
 INSERT INTO casesvc.category (categorypk, shortdescription, longdescription, eventtype, role, generatedactiontype, "group", oldcasesampleunittypes, newcasesampleunittype, recalccollectioninstrument)
-VALUES ('DISABLE_RESPONDENT_ENROLMENT', 'Disable Respondent Enrolment', 'Disable Respondent Enrolment', 'DISABLED',  NULL, NULL, NULL, 'BI', NULL, NULL);
+VALUES ('DISABLE_RESPONDENT_ENROLMENT', 'Disable Respondent Enrolment', 'Disable Respondent Enrolment', 'DISABLED',  NULL, NULL, NULL, 'BI', 'B', NULL);

--- a/src/main/resources/database/changes/release-10.54.0/changelog.yml
+++ b/src/main/resources/database/changes/release-10.54.0/changelog.yml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+
+  - changeSet:
+      id: 10.54.0-1
+      author: Andrew Millar
+      changes:
+        - sqlFile:
+            comment: Add DISABLE_RESPONDENT_ENROLMENT case event category
+            path: add_disable_respondent_enrolment_category.sql
+            relativeToChangelogFile: true
+            splitStatements: false

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImplTest.java
@@ -110,7 +110,6 @@ public class CaseServiceImplTest {
   private static final Integer ACTIONABLE_BI_CASE_FK = 11;
   private static final Integer INACTIONABLE_BUSINESS_UNIT_CASE_FK = 12;
   private static final Integer ANOTHER_ACTIONABLE_BI_CASE_FK = 13;
-  private static final Integer NEW_EMPTY_CASE = 14;
 
   private static final Integer CASEGROUP_PK = 1;
 
@@ -1164,18 +1163,6 @@ public class CaseServiceImplTest {
     CaseGroup cg = new CaseGroup();
     cg.setId(UUID.randomUUID());
     cg.setStatus(CaseGroupStatus.NOTSTARTED);
-    cg.setSampleUnitType("B");
-    return cg;
-  }
-
-  /**
-   * Make a completedtest case group
-   * @return a new test case group
-   */
-  private CaseGroup makeCompletedCaseGroup() {
-    CaseGroup cg = new CaseGroup();
-    cg.setId(UUID.randomUUID());
-    cg.setStatus(CaseGroupStatus.COMPLETE);
     cg.setSampleUnitType("B");
     return cg;
   }

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImplTest.java
@@ -1168,6 +1168,18 @@ public class CaseServiceImplTest {
   }
 
   /**
+   * Make a completed test case group
+   * @return a new test case group with status COMPLETE
+   */
+  private CaseGroup makeCompletedCaseGroup() {
+    CaseGroup cg = new CaseGroup();
+    cg.setId(UUID.randomUUID());
+    cg.setStatus(CaseGroupStatus.COMPLETE);
+    cg.setSampleUnitType("BI");
+    return cg;
+  }
+
+  /**
    * Make a test case
    * @return a new test case
    */
@@ -1545,6 +1557,41 @@ public class CaseServiceImplTest {
     verify(notificationPublisher, times(1)).sendNotification(any(CaseNotification.class));
     verify(caseRepo, times(1)).findByCaseGroupIdAndState(null, CaseState.ACTIONABLE);
     verify(caseGroupRepo, times(1)).findById(null);
+  }
+
+  /**
+   * A SUCCESSFUL_RESPONSE_UPLOAD event transitions an actionable BI case to INACTIONABLE, and all associated BI cases in the case group.
+   * The action service is notified of the transition of all BI Cases to stop them receiving communications.
+   * @throws Exception if fabricateEvent does
+   */
+  @Test
+  public void testEventSuccessfulDisableRespondentEnrolmentCompleteCasegroup() throws Exception {
+    when(caseRepo.findOne(ACTIONABLE_BI_CASE_FK)).thenReturn(cases.get(ACTIONABLE_BI_CASE_FK));
+    Category disableRespondentEnrolmentCategory = categories.get(CAT_DISABLE_RESPONDENT_ENROLMENT);
+    when(categoryRepo.findOne(CategoryDTO.CategoryName.DISABLE_RESPONDENT_ENROLMENT)).thenReturn(
+            disableRespondentEnrolmentCategory);
+    when(caseRepo.findByCaseGroupId(null)).thenReturn(Arrays.asList(cases.get(ACTIONABLE_BI_CASE_FK),
+            cases.get(ANOTHER_ACTIONABLE_BI_CASE_FK)));
+    when(caseRepo.findByCaseGroupIdAndState(null, CaseState.ACTIONABLE))
+            .thenReturn(Collections.singletonList(cases.get(ACTIONABLE_BI_CASE_FK)));
+    CaseGroup caseGroup = makeCompletedCaseGroup();
+    when(caseGroupRepo.findById(null)).thenReturn(caseGroup);
+
+    CaseEvent caseEvent = fabricateEvent(CategoryDTO.CategoryName.DISABLE_RESPONDENT_ENROLMENT, ACTIONABLE_BI_CASE_FK);
+    Case newCase = cases.get(ANOTHER_ACTIONABLE_BI_CASE_FK);
+    caseService.createCaseEvent(caseEvent, newCase);
+
+    verify(caseRepo, times(1)).findOne(ACTIONABLE_BI_CASE_FK);
+    verify(categoryRepo).findOne(CategoryDTO.CategoryName.DISABLE_RESPONDENT_ENROLMENT);
+    verify(caseEventRepository, times(1)).save(caseEvent);
+    ArgumentCaptor<Case> argument = ArgumentCaptor.forClass(Case.class);
+    verify(caseRepo, times(1)).saveAndFlush(argument.capture());
+    verify(internetAccessCodeSvcClientService, times(1)).disableIAC(any(String.class));
+    verify(caseRepo, times(1)).saveAndFlush(argument.capture());
+    verify(notificationPublisher, times(1)).sendNotification(any(CaseNotification.class));
+    verify(caseRepo, times(1)).findByCaseGroupIdAndState(null, CaseState.ACTIONABLE);
+    verify(caseGroupRepo, times(1)).findById(null);
+    verify(caseRepo, times(1)).saveAndFlush(argument.capture());
   }
 
   /**

--- a/src/test/resources/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImplTest.Case.json
+++ b/src/test/resources/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImplTest.Case.json
@@ -205,5 +205,18 @@
 		"iac": "",
 		"actionPlanId": "4381731e-e386-41a1-8462-26373744db81",
 		"responses": []
+	},
+	{
+		"id": "91fda7f2-3825-4bd4-baef-943a0ccf0859",
+		"casePK": 14,
+		"caseGroupFK":1,
+		"state": null,
+		"sampleUnitType": null,
+		"partyId": "3b136c4b-7a14-4904-9e01-13364dd7b972",
+		"createdDateTime": 1460732606544,
+		"createdBy": "me",
+		"iac": "",
+		"actionPlanId": null,
+		"responses": []
 	}
 ]

--- a/src/test/resources/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImplTest.Category.json
+++ b/src/test/resources/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImplTest.Category.json
@@ -555,4 +555,16 @@
     "oldCaseSampleUnitTypes": "BI",
     "eventType": null
   }
+,
+  {
+    "group": null,
+    "categoryName": "DISABLE_RESPONDENT_ENROLMENT",
+    "longDescription": "Offline Response Processed",
+    "shortDescription": "Offline Response Processed",
+    "role": null,
+    "generatedActionType": null,
+    "newCaseSampleUnitType": "B",
+    "oldCaseSampleUnitTypes": "BI",
+    "eventType": "DISABLED"
+  }
 ]


### PR DESCRIPTION
Added a new category `DISABLE_RESPONDENT_ENROLMENT` and added some logic to handle this event. This will transition a case to `INACTIONABLE` state and will create a new B-case if there are no remaining actionable cases and the casegroup status is not completed

Works with other PR's:
[response-operations-ui](https://github.com/ONSdigital/response-operations-ui/pull/123)
[rm-backstage](https://github.com/ONSdigital/ras-backstage/pull/96)
[ras-frontstage-api](https://github.com/ONSdigital/ras-frontstage-api/pull/60)
[ras-party](https://github.com/ONSdigital/ras-party/pull/122)
[rm-casesvc-api](https://github.com/ONSdigital/rm-casesvc-api/pull/13)

[Confluence](https://digitaleq.atlassian.net/wiki/spaces/RASB/pages/248545529/US022+Disable+respondent+enrolment+to+a+survey)
[Trello](https://trello.com/c/1ez85L0y/51-us022-int-disable-respondents-enrolment-to-a-survey-l)