### PR TITLE
Performance Improvement

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpoint.java
@@ -252,7 +252,7 @@ public final class CaseEndpoint implements CTPEndpoint {
   public ResponseEntity<CreatedCaseEventDTO> createCaseEvent(@PathVariable("caseId") final UUID caseId,
                                       @RequestBody @Valid final CaseEventCreationRequestDTO caseEventCreationRequestDTO,
                                       BindingResult bindingResult) throws CTPException, InvalidRequestException {
-    log.debug("Entering createCaseEvent with caseId {} and requestObject {}", caseId, caseEventCreationRequestDTO);
+    log.info("Entering createCaseEvent with caseId {} and requestObject {}", caseId, caseEventCreationRequestDTO);
 
     if (bindingResult.hasErrors()) {
       throw new InvalidRequestException("Binding errors for case event creation: ", bindingResult);

--- a/src/main/resources/application-cloud.yaml
+++ b/src/main/resources/application-cloud.yaml
@@ -98,7 +98,7 @@ collection-exercise-svc:
 
 case-distribution:
   retrieval-max: 50
-  delay-milli-seconds: 50000
+  delay-milli-seconds: 500
 
 redelivery-policy:
   maxRedeliveries: 10


### PR DESCRIPTION
- Changing `case-distribution_delay-milli-seconds` to 500. This is
required to speed up collectionExercise execution.

- Changing `createCaseEvent` logging to INFO. This is required to
investigate receipting issues without switching to DEBUG level.

- Changing `case-distribution_delay-milli-seconds` to 500 generates a
lot of noise in logs at DEBUG level. Hence, currently it is not recommended to leave
logging at DEBUG for a long time.