### PR TITLE
Fix/duplicate bi cases created when verification link clicked more than once

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/CaseGroupService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/CaseGroupService.java
@@ -59,6 +59,6 @@ public interface CaseGroupService extends CTPService {
    * @return a list of case groups related to the target by party and collection exercise
    * @throws CTPException thrown if an error occurs
    */
-  List<CaseGroup> transitionOtherCaseGroups(Case targetCase) throws CTPException;
+  List<CaseGroup> findCaseGroupsForExecutedCollectionExercises(Case targetCase) throws CTPException;
 
 }

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseGroupServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseGroupServiceImpl.java
@@ -97,7 +97,7 @@ public class CaseGroupServiceImpl implements CaseGroupService {
    * @return a list of other case groups related to the target by party and collection exercise
    * @throws CTPException thrown if database error etc
    */
-  public List<CaseGroup> transitionOtherCaseGroups(final Case targetCase) throws CTPException {
+  public List<CaseGroup> findCaseGroupsForExecutedCollectionExercises(final Case targetCase) throws CTPException {
     if (targetCase == null){
         throw new CTPException(CTPException.Fault.SYSTEM_ERROR, "Target case must be supplied");
     }

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImpl.java
@@ -280,12 +280,14 @@ public class CaseServiceImpl implements CaseService {
               .filter(c -> c.getSampleUnitType().toString().equals("BI") && c.getPartyId().equals(newCase.getPartyId()))
               .collect(Collectors.toList());
       if (biCases.size() != 0) {
-    	  	 log.warn("Existing BI case found during enrolment for partyid: {} for casegroup: {}", newCase.getPartyId().toString(), caseGroup.getCaseGroupPK());
+    	  	 log.warn("Existing BI case found during enrolment for partyid: {} for casegroup: {} with caseid: {}",
+    	  			 newCase.getPartyId().toString(), caseGroup.getCaseGroupPK(), biCases.get(0));
       } else {
           Case c = new Case();
           c.setPartyId(newCase.getPartyId());
           createNewCase(category, caseEvent, cases.get(0), c);
-          log.info("BI case created during enrolment for partyid: {} for casegroup: {}", newCase.getPartyId().toString(), caseGroup.getCaseGroupPK());
+          log.info("BI case created during enrolment for partyid: {} for casegroup: {}",
+        		  newCase.getPartyId().toString(), caseGroup.getId());
       }
     	  
       // Transition each of the B cases for the casegroup being enrolled for

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImpl.java
@@ -281,7 +281,7 @@ public class CaseServiceImpl implements CaseService {
               .collect(Collectors.toList());
       if (biCases.size() != 0) {
     	  	 log.warn("Existing BI case found during enrolment for partyid: {} for casegroup: {} with caseid: {}",
-    	  			 newCase.getPartyId().toString(), caseGroup.getCaseGroupPK(), biCases.get(0).getId());
+    	  			 newCase.getPartyId().toString(), caseGroup.getId(), biCases.get(0).getId());
       } else {
           Case c = new Case();
           c.setPartyId(newCase.getPartyId());

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImpl.java
@@ -195,8 +195,8 @@ public class CaseServiceImpl implements CaseService {
 
       if (caseEvent.getCategory().equals(CategoryDTO.CategoryName.RESPONDENT_ENROLED)) {
         // are there other case groups that need updating
-        List<CaseGroup> caseGroups = caseGroupService.transitionOtherCaseGroups(targetCase);
-        checkCaseState(category, caseGroups, caseEvent, newCase);
+        List<CaseGroup> caseGroups = caseGroupService.findCaseGroupsForExecutedCollectionExercises(targetCase);
+        processCaseCreationAndTransitionsDuringEnrolment(category, caseGroups, caseEvent, newCase);
       }
 
       else if (caseEvent.getCategory().equals(CategoryDTO.CategoryName.SUCCESSFUL_RESPONSE_UPLOAD)
@@ -264,28 +264,39 @@ public class CaseServiceImpl implements CaseService {
    * @param newCase a case to provide a party id
    * @throws CTPException thrown if database error etc
    */
-  private void checkCaseState(final Category category, final List<CaseGroup> caseGroups, final CaseEvent caseEvent,
+  private void processCaseCreationAndTransitionsDuringEnrolment(final Category category, final List<CaseGroup> caseGroups, final CaseEvent caseEvent,
                               final Case newCase) throws CTPException {
-    // check all case groups are type B. For surveys this is always true
-    List<CaseGroup> caseGroupsToUpdate = caseGroups
-            .stream()
-            .filter(cg -> cg.getSampleUnitType().toString().equals("B"))
-            .collect(Collectors.toList());
-    for (CaseGroup cg : caseGroupsToUpdate) {
-      // fetch cases associated to case group
-      List<Case> cases = caseRepo.findByCaseGroupFKOrderByCreatedDateTimeDesc(cg.getCaseGroupPK());
-      // find b cases
+	  
+    for (CaseGroup caseGroup : caseGroups) {
+    	
+      // fetch all B and BI cases associated to the case group being processed
+      List<Case> cases = caseRepo.findByCaseGroupFKOrderByCreatedDateTimeDesc(caseGroup.getCaseGroupPK());
+
+      // Create a new BI case for the respondent enrolling (if one doesn't already exit)
+      // This is primarily to guard against multiple RESPONDENT_ENROLED case events for the same user
+      // caused by a double click scenario in the verification email journey 
+      List<Case> biCases = cases
+              .stream()
+              .filter(c -> c.getSampleUnitType().toString().equals("BI") && c.getPartyId().equals(newCase.getPartyId()))
+              .collect(Collectors.toList());
+      if (biCases.size() != 0) {
+    	  	 log.warn("Existing BI case found during enrolment for partyid: {} for casegroup: {}", newCase.getPartyId().toString(), caseGroup.getCaseGroupPK());
+      } else {
+          Case c = new Case();
+          c.setPartyId(newCase.getPartyId());
+          createNewCase(category, caseEvent, cases.get(0), c);
+          log.info("BI case created during enrolment for partyid: {} for casegroup: {}", newCase.getPartyId().toString(), caseGroup.getCaseGroupPK());
+      }
+    	  
+      // Transition each of the B cases for the casegroup being enrolled for
       List<Case> bCases = cases
               .stream()
               .filter(c -> c.getSampleUnitType().toString().equals("B"))
               .collect(Collectors.toList());
-      // see if any case needs to transition
       for (Case bCase : bCases) {
         effectTargetCaseStateTransition(category, bCase);
       }
-      Case c = new Case();
-      c.setPartyId(newCase.getPartyId());
-      createNewCase(category, caseEvent, cases.get(0), c);
+      
     }
   }
 

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImpl.java
@@ -304,9 +304,9 @@ public class CaseServiceImpl implements CaseService {
       log.debug("RESPONDENT_ENROLED case event :: number of B cases found: {} for casegroupid: {} partyid {}", bCases.size(), caseGroup.getId(), newCase.getPartyId().toString());
       
       for (Case bCase : bCases) {
-    	    log.debug("RESPONDENT_ENROLED case event :: about to effectTargetCaseStateTransition() for {} for B case {}", category, bCase.getPartyId().toString());
+    	    log.debug("RESPONDENT_ENROLED case event :: about to effectTargetCaseStateTransition() for {} for B case {}", category, bCase.toString());
         effectTargetCaseStateTransition(category, bCase);
-        log.debug("RESPONDENT_ENROLED case event :: completed effectTargetCaseStateTransition() for {} for B case {}", category, bCase.getPartyId().toString());
+        log.debug("RESPONDENT_ENROLED case event :: completed effectTargetCaseStateTransition() for {} for B case {}", category, bCase.toString());
       }
       
     }
@@ -515,25 +515,25 @@ public class CaseServiceImpl implements CaseService {
       // so newstate == oldstate, but always want to disable iac if event is
       // DISABLED (ie as the result
       // of an online response after a refusal) or ACCOUNT_CREATED (for BRES)
-    	  log.debug("RESPONDENT_ENROLED case event :: In effectTargetCaseStateTransition() for {} for B case {}", category, targetCase.getPartyId().toString());
+    	  log.debug("RESPONDENT_ENROLED case event :: In effectTargetCaseStateTransition() for {} for B case {}", category, targetCase.toString());
       if (transitionEvent == CaseDTO.CaseEvent.DISABLED || transitionEvent == CaseDTO.CaseEvent.ACCOUNT_CREATED) {
-    	  	log.debug("RESPONDENT_ENROLED case event :: About to internetAccessCodeSvcClientService() for iac {} for B case {}", targetCase.getIac(), targetCase.getPartyId().toString());
+    	  	log.debug("RESPONDENT_ENROLED case event :: About to internetAccessCodeSvcClientService() for iac {} for B case {}", targetCase.getIac(), targetCase.toString());
     	  	internetAccessCodeSvcClientService.disableIAC(targetCase.getIac());
-    	  	log.debug("RESPONDENT_ENROLED case event :: Completed internetAccessCodeSvcClientService() for iac {} for B case {}", targetCase.getIac(), targetCase.getPartyId().toString());
+    	  	log.debug("RESPONDENT_ENROLED case event :: Completed internetAccessCodeSvcClientService() for iac {} for B case {}", targetCase.getIac(), targetCase.toString());
       }
 
       CaseState oldState = targetCase.getState();
       CaseState newState = null;
       // make the transition
-      log.debug("RESPONDENT_ENROLED case event :: About to caseSvcStateTransitionManager() for case {} oldstate: {}", targetCase.getPartyId().toString(), oldState);
+      log.debug("RESPONDENT_ENROLED case event :: About to caseSvcStateTransitionManager() for case {} oldstate: {}", targetCase.toString(), oldState);
       newState = caseSvcStateTransitionManager.transition(oldState, transitionEvent);
 
       // was a state change effected?
       if (!oldState.equals(newState)) {
         targetCase.setState(newState);
-        log.debug("RESPONDENT_ENROLED case event :: About to saveAndFlush() for case {}", targetCase.getPartyId().toString());
+        log.debug("RESPONDENT_ENROLED case event :: About to saveAndFlush() for case {}", targetCase.toString());
         caseRepo.saveAndFlush(targetCase);
-        log.debug("RESPONDENT_ENROLED case event :: About to sendNotification() for case {}", targetCase.getPartyId().toString());
+        log.debug("RESPONDENT_ENROLED case event :: About to sendNotification() for case {}", targetCase.toString());
         notificationPublisher.sendNotification(prepareCaseNotification(targetCase, transitionEvent));
       }
     }

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImpl.java
@@ -269,6 +269,8 @@ public class CaseServiceImpl implements CaseService {
 	  
     for (CaseGroup caseGroup : caseGroups) {
     	
+      log.debug("RESPONDENT_ENROLED case event :: Processing casegroup: {} for partyid: {}", caseGroup.getId(), newCase.getPartyId().toString());
+    	
       // fetch all B and BI cases associated to the case group being processed
       List<Case> cases = caseRepo.findByCaseGroupFKOrderByCreatedDateTimeDesc(caseGroup.getCaseGroupPK());
 
@@ -279,6 +281,9 @@ public class CaseServiceImpl implements CaseService {
               .stream()
               .filter(c -> c.getSampleUnitType().toString().equals("BI") && c.getPartyId().equals(newCase.getPartyId()))
               .collect(Collectors.toList());
+      
+      log.debug("RESPONDENT_ENROLED case event :: number of BI cases found: {} for casegroupid: {} partyid {}", biCases.size(), caseGroup.getId(), newCase.getPartyId().toString());
+  	
       if (biCases.size() != 0) {
     	  	 log.warn("Existing BI case found during enrolment for partyid: {} for casegroup: {} with caseid: {}",
     	  			 newCase.getPartyId().toString(), caseGroup.getId(), biCases.get(0).getId());
@@ -289,14 +294,19 @@ public class CaseServiceImpl implements CaseService {
           log.info("BI case created during enrolment for partyid: {} for casegroup: {}",
         		  newCase.getPartyId().toString(), caseGroup.getId());
       }
-    	  
+    	
       // Transition each of the B cases for the casegroup being enrolled for
       List<Case> bCases = cases
               .stream()
               .filter(c -> c.getSampleUnitType().toString().equals("B"))
               .collect(Collectors.toList());
+    
+      log.debug("RESPONDENT_ENROLED case event :: number of B cases found: {} for casegroupid: {} partyid {}", bCases.size(), caseGroup.getId(), newCase.getPartyId().toString());
+      
       for (Case bCase : bCases) {
+    	    log.debug("RESPONDENT_ENROLED case event :: about to effectTargetCaseStateTransition() for {} for B case {}", category, bCase.getPartyId().toString());
         effectTargetCaseStateTransition(category, bCase);
+        log.debug("RESPONDENT_ENROLED case event :: completed effectTargetCaseStateTransition() for {} for B case {}", category, bCase.getPartyId().toString());
       }
       
     }
@@ -505,19 +515,25 @@ public class CaseServiceImpl implements CaseService {
       // so newstate == oldstate, but always want to disable iac if event is
       // DISABLED (ie as the result
       // of an online response after a refusal) or ACCOUNT_CREATED (for BRES)
+    	  log.debug("RESPONDENT_ENROLED case event :: In effectTargetCaseStateTransition() for {} for B case {}", category, targetCase.getPartyId().toString());
       if (transitionEvent == CaseDTO.CaseEvent.DISABLED || transitionEvent == CaseDTO.CaseEvent.ACCOUNT_CREATED) {
-        internetAccessCodeSvcClientService.disableIAC(targetCase.getIac());
+    	  	log.debug("RESPONDENT_ENROLED case event :: About to internetAccessCodeSvcClientService() for iac {} for B case {}", targetCase.getIac(), targetCase.getPartyId().toString());
+    	  	internetAccessCodeSvcClientService.disableIAC(targetCase.getIac());
+    	  	log.debug("RESPONDENT_ENROLED case event :: Completed internetAccessCodeSvcClientService() for iac {} for B case {}", targetCase.getIac(), targetCase.getPartyId().toString());
       }
 
       CaseState oldState = targetCase.getState();
       CaseState newState = null;
       // make the transition
+      log.debug("RESPONDENT_ENROLED case event :: About to caseSvcStateTransitionManager() for case {} oldstate: {}", targetCase.getPartyId().toString(), oldState);
       newState = caseSvcStateTransitionManager.transition(oldState, transitionEvent);
 
       // was a state change effected?
       if (!oldState.equals(newState)) {
         targetCase.setState(newState);
+        log.debug("RESPONDENT_ENROLED case event :: About to saveAndFlush() for case {}", targetCase.getPartyId().toString());
         caseRepo.saveAndFlush(targetCase);
+        log.debug("RESPONDENT_ENROLED case event :: About to sendNotification() for case {}", targetCase.getPartyId().toString());
         notificationPublisher.sendNotification(prepareCaseNotification(targetCase, transitionEvent));
       }
     }

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImpl.java
@@ -281,7 +281,7 @@ public class CaseServiceImpl implements CaseService {
               .collect(Collectors.toList());
       if (biCases.size() != 0) {
     	  	 log.warn("Existing BI case found during enrolment for partyid: {} for casegroup: {} with caseid: {}",
-    	  			 newCase.getPartyId().toString(), caseGroup.getCaseGroupPK(), biCases.get(0));
+    	  			 newCase.getPartyId().toString(), caseGroup.getCaseGroupPK(), biCases.get(0).getId());
       } else {
           Case c = new Case();
           c.setPartyId(newCase.getPartyId());

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImplTest.java
@@ -1103,7 +1103,7 @@ public class CaseServiceImplTest {
     List<CollectionExerciseDTO> listCollex = Collections.singletonList(makeCollectionExercise());
     when(collectionExerciseSvcClientService.getCollectionExercises(null)).thenReturn(listCollex);
     List<CaseGroup> theseCaseGroups = Collections.singletonList(makeCaseGroup());
-    when(caseGroupService.transitionOtherCaseGroups(any())).thenReturn(theseCaseGroups);
+    when(caseGroupService.findCaseGroupsForExecutedCollectionExercises(any())).thenReturn(theseCaseGroups);
     CaseGroup caseGroup = makeCaseGroup();
     when(caseGroupRepo.findOne(ENROLMENT_CASE_INDIVIDUAL_FK)).thenReturn(caseGroup);
     List<Case> c = Collections.singletonList(makeCase());


### PR DESCRIPTION
When multiple RESPONDENT_ENROLED case events are posted, multiple BI cases are created for case groups (for the respondent enrolling). This PR guards against that scenario. This has been tested locally and in the performance test environment, by recreating the double click of the verification email link.

The result of this can be replicated by the following request

curl -v -u admin:secret -L -X POST http://localhost:8171/cases/<<CASE_UUID>>/events \
-H 'Content-Type: application/json' \
-d '{"description": "Respondent enroled", "category": "RESPONDENT_ENROLED", "partyId": "<<RESPONDENT_UUID>>", "createdBy": "Party Service"}'