### PR TITLE
Fix link new b cases to business

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.product</groupId>
       <artifactId>casesvc-api</artifactId>
-      <version>10.49.11</version>
+      <version>10.49.13</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImpl.java
@@ -410,7 +410,6 @@ public class CaseServiceImpl implements CaseService {
         newCase.setCollectionInstrumentId(targetCase.getCollectionInstrumentId());
       }
 
-      log.info(newCase.getPartyId().toString(), '2');
       createNewCaseFromEvent(caseEvent, targetCase, newCase, category);
     }
   }
@@ -424,7 +423,6 @@ public class CaseServiceImpl implements CaseService {
    */
   private void buildNewCase(Category category, Case newCase, Case targetCase) {
 
-    log.info(newCase.getPartyId().toString(), '3');
     newCase.setSampleUnitType(SampleUnitType.valueOf(category.getNewCaseSampleUnitType()));
 
     // set case group id to the same as
@@ -441,7 +439,6 @@ public class CaseServiceImpl implements CaseService {
       }
     }
 
-    log.info(newCase.getPartyId().toString(), '4');
   }
 
   /**
@@ -547,7 +544,6 @@ public class CaseServiceImpl implements CaseService {
    * @return the new case
    */
   private Case createNewCaseFromEvent(CaseEvent caseEvent, Case targetCase, Case newCase, Category caseEventCategory) {
-    log.info(newCase.getPartyId().toString(), '5');
     Case persistedCase = saveNewCase(caseEvent, targetCase, newCase);
     // NOTE the action service does not need to be notified of the creation of
     // the new case - yet
@@ -569,7 +565,6 @@ public class CaseServiceImpl implements CaseService {
    * @return the persisted case
    */
   private Case saveNewCase(CaseEvent caseEvent, Case targetCase, Case newCase) {
-    log.info(newCase.getPartyId().toString(), '6');
     newCase.setId(UUID.randomUUID());
     newCase.setState(CaseState.REPLACEMENT_INIT);
     newCase.setCreatedDateTime(DateTimeUtil.nowUTC());

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImpl.java
@@ -219,6 +219,13 @@ public class CaseServiceImpl implements CaseService {
         }
       }
 
+      else if (caseEvent.getCategory().equals(CategoryDTO.CategoryName.REPLACED) && category.getNewCaseSampleUnitType().equals(SampleUnitType.B))  {
+          CaseGroup caseGroup = caseGroupRepo.findById(targetCase.getCaseGroupId());
+          newCase.setPartyId(caseGroup.getPartyId());
+          createNewCase(category, caseEvent, targetCase, newCase);
+          effectTargetCaseStateTransition(category, targetCase);
+      }
+
       else {
         createNewCase(category, caseEvent, targetCase, newCase);
         effectTargetCaseStateTransition(category, targetCase);
@@ -403,6 +410,7 @@ public class CaseServiceImpl implements CaseService {
         newCase.setCollectionInstrumentId(targetCase.getCollectionInstrumentId());
       }
 
+      log.info(newCase.getPartyId().toString(), '2');
       createNewCaseFromEvent(caseEvent, targetCase, newCase, category);
     }
   }
@@ -415,6 +423,8 @@ public class CaseServiceImpl implements CaseService {
    * @param newCase the new case to be created
    */
   private void buildNewCase(Category category, Case newCase, Case targetCase) {
+
+    log.info(newCase.getPartyId().toString(), '3');
     newCase.setSampleUnitType(SampleUnitType.valueOf(category.getNewCaseSampleUnitType()));
 
     // set case group id to the same as
@@ -430,6 +440,8 @@ public class CaseServiceImpl implements CaseService {
         newCase.setActionPlanId(caseType.getActionPlanId());
       }
     }
+
+    log.info(newCase.getPartyId().toString(), '4');
   }
 
   /**
@@ -535,6 +547,7 @@ public class CaseServiceImpl implements CaseService {
    * @return the new case
    */
   private Case createNewCaseFromEvent(CaseEvent caseEvent, Case targetCase, Case newCase, Category caseEventCategory) {
+    log.info(newCase.getPartyId().toString(), '5');
     Case persistedCase = saveNewCase(caseEvent, targetCase, newCase);
     // NOTE the action service does not need to be notified of the creation of
     // the new case - yet
@@ -556,6 +569,7 @@ public class CaseServiceImpl implements CaseService {
    * @return the persisted case
    */
   private Case saveNewCase(CaseEvent caseEvent, Case targetCase, Case newCase) {
+    log.info(newCase.getPartyId().toString(), '6');
     newCase.setId(UUID.randomUUID());
     newCase.setState(CaseState.REPLACEMENT_INIT);
     newCase.setCreatedDateTime(DateTimeUtil.nowUTC());

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImplTest.java
@@ -1164,6 +1164,7 @@ public class CaseServiceImplTest {
     cg.setId(UUID.randomUUID());
     cg.setStatus(CaseGroupStatus.NOTSTARTED);
     cg.setSampleUnitType("B");
+    cg.setPartyId(UUID.randomUUID());
     return cg;
   }
 


### PR DESCRIPTION
This is a fix for disable respondent enrolment when the respondent is the last actionable user for a case group a new B case is created so the business gets a letter for someone to enrol for a survey for that business. The current implementation links the new B case to a respondent rather than a business. Due to this the new enrolment codes do not work. This will fix this.