### PR TITLE
Create a manifest file with no envs

### DIFF
--- a/manifest-no-envs.yml
+++ b/manifest-no-envs.yml
@@ -1,0 +1,10 @@
+applications:
+- name: casesvc
+  instances: 1
+  timeout: 180
+  memory: 1024M
+  path: target/casesvc.jar
+  services:
+    - rm-pg-db
+    - rm-redis
+    - rm-rabbitmq


### PR DESCRIPTION
We need to override environmental variables at deployment time. If a
variables is specified in the manifest file it isn't being overriden.