### PR TITLE
Defect: No comms when respondent's enrolment is disabled after generating new enrolment code

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/domain/repository/CaseRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/domain/repository/CaseRepository.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.ons.ctp.response.casesvc.domain.model.Case;
 import uk.gov.ons.ctp.response.casesvc.representation.CaseState;
+import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO;
 
 import java.util.List;
 import java.util.UUID;
@@ -48,7 +49,8 @@ public interface CaseRepository extends JpaRepository<Case, Integer> {
    * @param state the case group state
    * @return the cases in the group
    */
-  List<Case> findByCaseGroupIdAndState(UUID caseGroupFK, CaseState state);
+  List<Case> findByCaseGroupIdAndStateAndSampleUnitType(UUID caseGroupFK, CaseState state,
+                                                        SampleUnitDTO.SampleUnitType sampleUnitType);
 
   /**
    * Find cases assigned to the given iac

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImpl.java
@@ -207,8 +207,8 @@ public class CaseServiceImpl implements CaseService {
 
       else if (caseEvent.getCategory().equals(CategoryDTO.CategoryName.DISABLE_RESPONDENT_ENROLMENT)) {
         effectTargetCaseStateTransition(category, targetCase);
-        List<Case> actionableCases = caseRepo.findByCaseGroupIdAndState(
-                targetCase.getCaseGroupId(), CaseState.ACTIONABLE);
+        List<Case> actionableCases = caseRepo.findByCaseGroupIdAndStateAndSampleUnitType(
+                targetCase.getCaseGroupId(), CaseState.ACTIONABLE, SampleUnitType.BI);
         CaseGroup caseGroup = caseGroupRepo.findById(targetCase.getCaseGroupId());
 
         // Create a new case if no actionable case remain and casegroup is not in a complete state

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImplTest.java
@@ -1526,7 +1526,8 @@ public class CaseServiceImplTest {
             disableRespondentEnrolmentCategory);
     when(caseRepo.findByCaseGroupId(null)).thenReturn(Arrays.asList(cases.get(ACTIONABLE_BI_CASE_FK),
             cases.get(ANOTHER_ACTIONABLE_BI_CASE_FK)));
-    when(caseRepo.findByCaseGroupIdAndState(null, CaseState.ACTIONABLE))
+    when(caseRepo.findByCaseGroupIdAndStateAndSampleUnitType(null, CaseState.ACTIONABLE,
+            SampleUnitDTO.SampleUnitType.BI))
             .thenReturn(Collections.singletonList(cases.get(ACTIONABLE_BI_CASE_FK)));
     CaseGroup caseGroup = makeCaseGroup();
     when(caseGroupRepo.findById(null)).thenReturn(caseGroup);
@@ -1543,7 +1544,8 @@ public class CaseServiceImplTest {
     verify(internetAccessCodeSvcClientService, times(1)).disableIAC(any(String.class));
     verify(caseRepo, times(1)).saveAndFlush(argument.capture());
     verify(notificationPublisher, times(1)).sendNotification(any(CaseNotification.class));
-    verify(caseRepo, times(1)).findByCaseGroupIdAndState(null, CaseState.ACTIONABLE);
+    verify(caseRepo, times(1)).findByCaseGroupIdAndStateAndSampleUnitType(null,
+            CaseState.ACTIONABLE, SampleUnitDTO.SampleUnitType.BI);
     verify(caseGroupRepo, times(1)).findById(null);
   }
 
@@ -1560,7 +1562,9 @@ public class CaseServiceImplTest {
             disableRespondentEnrolmentCategory);
     when(caseRepo.findByCaseGroupId(null)).thenReturn(Arrays.asList(cases.get(ACTIONABLE_BI_CASE_FK),
             cases.get(ANOTHER_ACTIONABLE_BI_CASE_FK)));
-    when(caseRepo.findByCaseGroupIdAndState(null, CaseState.ACTIONABLE)).thenReturn(Collections.emptyList());
+    when(caseRepo.findByCaseGroupIdAndStateAndSampleUnitType(null, CaseState.ACTIONABLE,
+            SampleUnitDTO.SampleUnitType.BI))
+            .thenReturn(Collections.emptyList());
     CaseGroup caseGroup = makeCaseGroup();
     when(caseGroupRepo.findById(null)).thenReturn(caseGroup);
     Case newCase = cases.get(ANOTHER_ACTIONABLE_BI_CASE_FK);
@@ -1576,7 +1580,8 @@ public class CaseServiceImplTest {
     verify(caseRepo, times(2)).saveAndFlush(argument.capture());
     verify(internetAccessCodeSvcClientService, times(1)).disableIAC(any(String.class));
     verify(notificationPublisher, times(1)).sendNotification(any(CaseNotification.class));
-    verify(caseRepo, times(1)).findByCaseGroupIdAndState(null, CaseState.ACTIONABLE);
+    verify(caseRepo, times(1)).findByCaseGroupIdAndStateAndSampleUnitType(null,
+            CaseState.ACTIONABLE, SampleUnitDTO.SampleUnitType.BI);
     verify(caseGroupRepo, times(1)).findById(null);
   }
 


### PR DESCRIPTION
Previously, when a respondent enrolment was disabled, we were only creating a new B case when there were no ACTIONABLE cases for the given casegroups
We actually want to create this new case when there are no ACTIONABLE BI cases

[Trello](https://trello.com/c/qPFjHpuH/195-defect-ru-respondent-does-not-receive-any-comms-when-respondents-enrolment-is-disabled-after-generating-new-enrolment-code)