### PR TITLE
Remove source case Id for B cases being created

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.product</groupId>
       <artifactId>casesvc-api</artifactId>
-      <version>10.49.11</version>
+      <version>10.49.13</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImpl.java
@@ -2,7 +2,6 @@ package uk.gov.ons.ctp.response.casesvc.service.impl;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections.CollectionUtils;
-import org.eclipse.jdt.core.dom.NullLiteral;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImpl.java
@@ -2,6 +2,7 @@ package uk.gov.ons.ctp.response.casesvc.service.impl;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections.CollectionUtils;
+import org.eclipse.jdt.core.dom.NullLiteral;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -193,35 +194,33 @@ public class CaseServiceImpl implements CaseService {
 
       transitionCaseGroupStatus(targetCase, caseEvent);
 
-      if (caseEvent.getCategory().equals(CategoryDTO.CategoryName.RESPONDENT_ENROLED)) {
-        // are there other case groups that need updating
-        List<CaseGroup> caseGroups = caseGroupService.findCaseGroupsForExecutedCollectionExercises(targetCase);
-        processCaseCreationAndTransitionsDuringEnrolment(category, caseGroups, caseEvent, newCase);
-      }
+      switch (caseEvent.getCategory()) {
 
-      else if (caseEvent.getCategory().equals(CategoryDTO.CategoryName.SUCCESSFUL_RESPONSE_UPLOAD)
-               || caseEvent.getCategory().equals(CategoryDTO.CategoryName.COMPLETED_BY_PHONE)) {
-        createNewCase(category, caseEvent, targetCase, newCase);
-        updateAllAssociatedBiCases(targetCase, category);
-      }
-
-      else if (caseEvent.getCategory().equals(CategoryDTO.CategoryName.DISABLE_RESPONDENT_ENROLMENT)) {
-        effectTargetCaseStateTransition(category, targetCase);
-        List<Case> actionableCases = caseRepo.findByCaseGroupIdAndStateAndSampleUnitType(
-                targetCase.getCaseGroupId(), CaseState.ACTIONABLE, SampleUnitType.BI);
-        CaseGroup caseGroup = caseGroupRepo.findById(targetCase.getCaseGroupId());
-
-        // Create a new case if no actionable case remain and casegroup is not in a complete state
-        if (actionableCases.isEmpty()
-            && !caseGroup.getStatus().equals(CaseGroupStatus.COMPLETE)
-            && !caseGroup.getStatus().equals(CaseGroupStatus.COMPLETEDBYPHONE)) {
+        case RESPONDENT_ENROLED:
+          List<CaseGroup> caseGroups = caseGroupService.findCaseGroupsForExecutedCollectionExercises(targetCase);
+          processCaseCreationAndTransitionsDuringEnrolment(category, caseGroups, caseEvent, newCase);
+          break;
+        case SUCCESSFUL_RESPONSE_UPLOAD: case COMPLETED_BY_PHONE:
           createNewCase(category, caseEvent, targetCase, newCase);
-        }
-      }
+          updateAllAssociatedBiCases(targetCase, category);
+          break;
+        case DISABLE_RESPONDENT_ENROLMENT:
+          effectTargetCaseStateTransition(category, targetCase);
+          List<Case> actionableCases = caseRepo.findByCaseGroupIdAndStateAndSampleUnitType(
+                  targetCase.getCaseGroupId(), CaseState.ACTIONABLE, SampleUnitType.BI);
+          CaseGroup caseGroup = caseGroupRepo.findById(targetCase.getCaseGroupId());
 
-      else {
-        createNewCase(category, caseEvent, targetCase, newCase);
-        effectTargetCaseStateTransition(category, targetCase);
+          // Create a new case if no actionable case remain and casegroup is not in a complete state
+          if (actionableCases.isEmpty()
+                  && !caseGroup.getStatus().equals(CaseGroupStatus.COMPLETE)
+                  && !caseGroup.getStatus().equals(CaseGroupStatus.COMPLETEDBYPHONE)) {
+            createNewCase(category, caseEvent, targetCase, newCase);
+          }
+          break;
+        default:
+          createNewCase(category, caseEvent, targetCase, newCase);
+          effectTargetCaseStateTransition(category, targetCase);
+          break;
       }
     }
 
@@ -561,7 +560,13 @@ public class CaseServiceImpl implements CaseService {
     newCase.setCreatedDateTime(DateTimeUtil.nowUTC());
     newCase.setCaseGroupFK(targetCase.getCaseGroupFK());
     newCase.setCreatedBy(caseEvent.getCreatedBy());
-    newCase.setSourceCaseId(targetCase.getCasePK());
+    if (newCase.getSampleUnitType() == SampleUnitType.B) {
+      newCase.setSourceCaseId(null);
+    }
+    else {
+      newCase.setSourceCaseId(targetCase.getCasePK());
+    }
+
     return caseRepo.saveAndFlush(newCase);
   }
 


### PR DESCRIPTION
In the action service if the source case for a B case is not null it is linked back to a BI case. This will fix this so all B cases should not have a source case. Tested with the disable enrolment story as this is where the defect was found.