### PR TITLE
Us050d change response status to no longer required

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.product</groupId>
       <artifactId>casesvc-api</artifactId>
-      <version>10.49.11</version>
+      <version>10.49.14-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.product</groupId>
       <artifactId>casesvc-api</artifactId>
-      <version>10.49.14-SNAPSHOT</version>
+      <version>10.49.14</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/state/CaseSvcStateTransitionManagerFactory.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/state/CaseSvcStateTransitionManagerFactory.java
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Component;
 import uk.gov.ons.ctp.common.state.BasicStateTransitionManager;
 import uk.gov.ons.ctp.common.state.StateTransitionManager;
 import uk.gov.ons.ctp.common.state.StateTransitionManagerFactory;
-import uk.gov.ons.ctp.response.casesvc.domain.model.Case;
 import uk.gov.ons.ctp.response.casesvc.representation.CaseDTO.CaseEvent;
 import uk.gov.ons.ctp.response.casesvc.representation.CaseGroupStatus;
 import uk.gov.ons.ctp.response.casesvc.representation.CaseState;

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/state/CaseSvcStateTransitionManagerFactory.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/state/CaseSvcStateTransitionManagerFactory.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component;
 import uk.gov.ons.ctp.common.state.BasicStateTransitionManager;
 import uk.gov.ons.ctp.common.state.StateTransitionManager;
 import uk.gov.ons.ctp.common.state.StateTransitionManagerFactory;
+import uk.gov.ons.ctp.response.casesvc.domain.model.Case;
 import uk.gov.ons.ctp.response.casesvc.representation.CaseDTO.CaseEvent;
 import uk.gov.ons.ctp.response.casesvc.representation.CaseGroupStatus;
 import uk.gov.ons.ctp.response.casesvc.representation.CaseState;
@@ -53,21 +54,24 @@ public class CaseSvcStateTransitionManagerFactory implements StateTransitionMana
   private StateTransitionManager<CaseGroupStatus, CategoryDTO.CategoryName> caseGroupStateTransitionManager() {
     ImmutableTable.Builder<CaseGroupStatus, CategoryDTO.CategoryName, CaseGroupStatus> builder = ImmutableTable.builder();
 
-    // From not started on ci downloaded, eq launch, successful response upload, completed by phone to in progress, in progress, completed, completed by phone
+    // From not started on ci downloaded, eq launch, successful response upload, completed by phone to in progress, in progress, completed, completed by phone, no longer required
     builder.put(CaseGroupStatus.NOTSTARTED, CategoryDTO.CategoryName.COLLECTION_INSTRUMENT_DOWNLOADED, CaseGroupStatus.INPROGRESS);
     builder.put(CaseGroupStatus.NOTSTARTED, CategoryDTO.CategoryName.EQ_LAUNCH, CaseGroupStatus.INPROGRESS);
     builder.put(CaseGroupStatus.NOTSTARTED, CategoryDTO.CategoryName.SUCCESSFUL_RESPONSE_UPLOAD, CaseGroupStatus.COMPLETE);
     builder.put(CaseGroupStatus.NOTSTARTED, CategoryDTO.CategoryName.COMPLETED_BY_PHONE, CaseGroupStatus.COMPLETEDBYPHONE);
+    builder.put(CaseGroupStatus.NOTSTARTED, CategoryDTO.CategoryName.NO_LONGER_REQUIRED, CaseGroupStatus.NOLONGERREQUIRED);
     
     // From in progress on response processed by SDX to complete   
     builder.put(CaseGroupStatus.INPROGRESS, CategoryDTO.CategoryName.OFFLINE_RESPONSE_PROCESSED, CaseGroupStatus.COMPLETE);
 
-    // From in progress on successful response upload, completed by phone to completed, completed by phone
+    // From in progress on successful response upload, completed by phone to completed, completed by phone, no longer required
     builder.put(CaseGroupStatus.INPROGRESS, CategoryDTO.CategoryName.SUCCESSFUL_RESPONSE_UPLOAD, CaseGroupStatus.COMPLETE);
     builder.put(CaseGroupStatus.INPROGRESS, CategoryDTO.CategoryName.COMPLETED_BY_PHONE, CaseGroupStatus.COMPLETEDBYPHONE);
+    builder.put(CaseGroupStatus.INPROGRESS, CategoryDTO.CategoryName.NO_LONGER_REQUIRED, CaseGroupStatus.NOLONGERREQUIRED);
 
     // From reopened on completed by phone to completed by phone
     builder.put(CaseGroupStatus.REOPENED, CategoryDTO.CategoryName.COMPLETED_BY_PHONE, CaseGroupStatus.COMPLETEDBYPHONE);
+    builder.put(CaseGroupStatus.REOPENED, CategoryDTO.CategoryName.NO_LONGER_REQUIRED, CaseGroupStatus.NOLONGERREQUIRED);
 
     return new BasicStateTransitionManager<>(builder.build().rowMap());
   }

--- a/src/main/resources/database/changelog-master.yml
+++ b/src/main/resources/database/changelog-master.yml
@@ -41,3 +41,6 @@ databaseChangeLog:
 
   - include:
       file: database/changes/release-10.54.0/changelog.yml
+
+  - include:
+      file: database/changes/release-10.55.0/changelog.yml

--- a/src/main/resources/database/changes/release-10.55.0/add_no_longer_required_event.sql
+++ b/src/main/resources/database/changes/release-10.55.0/add_no_longer_required_event.sql
@@ -1,2 +1,2 @@
 INSERT INTO casesvc.category ("categorypk", "shortdescription", "longdescription", "eventtype", "role", "generatedactiontype", "group", "oldcasesampleunittypes", "newcasesampleunittype", "recalccollectioninstrument")
-VALUES ('NO_LONGER_REQUIRED', 'No Longer Required', 'No Longer Required', 'DEACTIVATED', 'NULL', 'NULL', 'NULL', 'B, BI', 'NULL', NULL)
+VALUES ('NO_LONGER_REQUIRED', 'No Longer Required', 'No Longer Required', 'DEACTIVATED', NULL, NULL, NULL, 'B, BI', NULL, NULL)

--- a/src/main/resources/database/changes/release-10.55.0/add_no_longer_required_event.sql
+++ b/src/main/resources/database/changes/release-10.55.0/add_no_longer_required_event.sql
@@ -1,0 +1,2 @@
+INSERT INTO casesvc.category ("categorypk", "shortdescription", "longdescription", "eventtype", "role", "generatedactiontype", "group", "oldcasesampleunittypes", "newcasesampleunittype", "recalccollectioninstrument")
+VALUES ('NO_LONGER_REQUIRED', 'No Longer Required', 'No Longer Required', 'DEACTIVATED', 'NULL', 'NULL', 'NULL', 'B, BI', 'NULL', NULL)

--- a/src/main/resources/database/changes/release-10.55.0/changelog.yml
+++ b/src/main/resources/database/changes/release-10.55.0/changelog.yml
@@ -6,6 +6,6 @@ databaseChangeLog:
       changes:
         - sqlFile:
             comment: Add NO_LONGER_REQUIRED case event category
-            path: add_no_longer_required_event.sql_category.sql
+            path: add_no_longer_required_event.sql
             relativeToChangelogFile: true
             splitStatements: false

--- a/src/main/resources/database/changes/release-10.55.0/changelog.yml
+++ b/src/main/resources/database/changes/release-10.55.0/changelog.yml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+
+  - changeSet:
+      id: 10.55.0-1
+      author: Andrew Millar
+      changes:
+        - sqlFile:
+            comment: Add NO_LONGER_REQUIRED case event category
+            path: add_no_longer_required_event.sql_category.sql
+            relativeToChangelogFile: true
+            splitStatements: false

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/state/StateTransitionManagerUnitTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/state/StateTransitionManagerUnitTest.java
@@ -156,6 +156,18 @@ public class StateTransitionManagerUnitTest {
   }
 
   @Test
+  public void givenCaseGroupStateNotStartedWhenNoLongerRequiredThenNoLongerRequired() throws CTPException {
+    // Given
+    CaseGroupStatus notStarted = CaseGroupStatus.NOTSTARTED;
+
+    // When
+    CaseGroupStatus destinationState = caseGroupStateMachine.transition(notStarted, CategoryDTO.CategoryName.NO_LONGER_REQUIRED);
+
+    // Then
+    assertEquals(destinationState, CaseGroupStatus.NOLONGERREQUIRED);
+  }
+
+  @Test
   public void givenCaseGroupStateInProgressWhenSuccessfulResponseUploadThenComplete() throws CTPException {
     // Given
     CaseGroupStatus inProgress = CaseGroupStatus.INPROGRESS;
@@ -180,6 +192,18 @@ public class StateTransitionManagerUnitTest {
   }
 
   @Test
+  public void givenCaseGroupStateInProgressWhenNoLongerRequiredThenNoLongerRequired() throws CTPException {
+    // Given
+    CaseGroupStatus inProgress = CaseGroupStatus.INPROGRESS;
+
+    // When
+    CaseGroupStatus destinationState = caseGroupStateMachine.transition(inProgress, CategoryDTO.CategoryName.NO_LONGER_REQUIRED);
+
+    // Then
+    assertEquals(destinationState, CaseGroupStatus.NOLONGERREQUIRED);
+  }
+
+  @Test
   public void givenCaseGroupStateReopenedWhenCompletedByPhoneThenCompletedByPhone() throws CTPException {
     // Given
     CaseGroupStatus reopened = CaseGroupStatus.REOPENED;
@@ -189,6 +213,18 @@ public class StateTransitionManagerUnitTest {
 
     // Then
     assertEquals(destinationState, CaseGroupStatus.COMPLETEDBYPHONE);
+  }
+
+  @Test
+  public void givenCaseGroupStateReopenedWhenNoLongerRequiredThenNoLongerRequired() throws CTPException {
+    // Given
+    CaseGroupStatus reopened = CaseGroupStatus.REOPENED;
+
+    // When
+    CaseGroupStatus destinationState = caseGroupStateMachine.transition(reopened, CategoryDTO.CategoryName.NO_LONGER_REQUIRED);
+
+    // Then
+    assertEquals(destinationState, CaseGroupStatus.NOLONGERREQUIRED);
   }
   
   @Test


### PR DESCRIPTION
Added new case event category `NO_LONGER_REQUIRED` to liquibase script

[Trello](https://trello.com/c/2a1r2ZJM/105-us050d-int-manually-change-the-response-status-for-a-given-ru-survey-ce-to-no-longer-required-l)
[Confluence](https://digitaleq.atlassian.net/wiki/spaces/RASB/pages/282132485/US050d+INT+Manually+change+the+response+status+for+a+given+RU+Survey+CE+to+No+Longer+Required+L)