### PR TITLE
Added case service state diagrams and means to build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ target
 *.DS_Store
 /.apt_generated/
 /.apt_generated/
+
+diagrams/*.svg
+plantuml.jar

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,17 @@
-DIAGRAM_DIR=diagrams
-UML_FILES=$(wildcard $(DIAGRAM_DIR)/*.puml)
-SVG_FILES := $(patsubst $(DIAGRAM_DIR)/%.puml,$(DIAGRAM_DIR)/%.svg,$(UML_FILES))
+DOT := $(shell command -v dot 2> /dev/null)
 
-diagrams: download-plantuml $(SVG_FILES)
+diagrams: ensure-graphviz download-plantuml
+	java -jar plantuml.jar -tsvg diagrams/*.puml
 
 clean:
-	rm plantuml.jar; rm diagrams/*.svg
+	rm -f plantuml.jar; rm -f diagrams/*.svg
 
 download-plantuml:
 ifeq (,$(wildcard plantuml.jar))
 	curl -L --output plantuml.jar https://downloads.sourceforge.net/project/plantuml/plantuml.jar
+endif 
+
+ensure-graphviz:
+ifndef DOT
+	$(error "The dot command is not available - please install graphviz (brew install graphviz)")
 endif
-
-%.svg : %.puml
-	 java -jar plantuml.jar -tsvg $^
-

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
-diagrams: download-plantuml diagrams/case-state.svg diagrams/case-group-state.svg
+DIAGRAM_DIR=diagrams
+UML_FILES=$(wildcard $(DIAGRAM_DIR)/*.puml)
+SVG_FILES := $(patsubst $(DIAGRAM_DIR)/%.puml,$(DIAGRAM_DIR)/%.svg,$(UML_FILES))
+
+diagrams: download-plantuml $(SVG_FILES)
 
 clean:
 	rm plantuml.jar; rm diagrams/*.svg

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+diagrams: download-plantuml diagrams/case-state.svg diagrams/case-group-state.svg
+
+clean:
+	rm plantuml.jar; rm diagrams/*.svg
+
+download-plantuml:
+ifeq (,$(wildcard plantuml.jar))
+	curl -L --output plantuml.jar https://downloads.sourceforge.net/project/plantuml/plantuml.jar
+endif
+
+%.svg : %.puml
+	 java -jar plantuml.jar -tsvg $^
+

--- a/diagrams/case-group-state.puml
+++ b/diagrams/case-group-state.puml
@@ -1,0 +1,22 @@
+@startuml
+skinparam state {
+    BackgroundColor HoneyDew
+}
+
+[*] --> NOTSTARTED
+NOTSTARTED --> INPROGRESS : collection_instrument_downloaded [[https://github.com/ONSdigital/ras-frontstage-api/blob/master/frontstage_api/controllers/collection_instrument_controller.py#L33 *]]
+NOTSTARTED --> INPROGRESS : eq_launch [[https://github.com/ONSdigital/ras-frontstage-api/blob/master/frontstage_api/resources/surveys/generate_eq_url.py#L51 *]]
+NOTSTARTED --> COMPLETE : successful_response_upload [[https://github.com/ONSdigital/ras-frontstage-api/blob/master/frontstage_api/controllers/collection_instrument_controller.py#L54 *]]
+
+NOTSTARTED --> COMPLETEDBYPHONE : completed_by_phone
+NOTSTARTED --> NOLONGERREQUIRED : no_longer_required
+    
+INPROGRESS --> COMPLETE : offline_response_processed [[https://github.com/ONSdigital/rm-case-service/blob/master/src/main/java/uk/gov/ons/ctp/response/casesvc/message/impl/CaseReceiptReceiverImpl.java#L60 *]]
+INPROGRESS --> COMPLETE : successful_response_upload [[https://github.com/ONSdigital/ras-frontstage-api/blob/888192443e7f2a6bcd3ce72ce3b0db32d11e85bb/frontstage_api/controllers/collection_instrument_controller.py#L54 *]]
+
+INPROGRESS --> COMPLETEDBYPHONE : completed_by_phone [[https://github.com/ONSdigital/response-operations-ui/blob/master/response_operations_ui/templates/change-response-status.html#L59 *]]
+INPROGRESS --> NOLONGERREQUIRED : no_longer_required [[https://github.com/ONSdigital/response-operations-ui/blob/master/response_operations_ui/templates/change-response-status.html#L59 *]]
+
+REOPENED --> COMPLETEDBYPHONE : completed_by_phone [[https://github.com/ONSdigital/response-operations-ui/blob/master/response_operations_ui/templates/change-response-status.html#L59 *]]
+REOPENED --> NOLONGERREQUIRED : no_longer_required [[https://github.com/ONSdigital/response-operations-ui/blob/master/response_operations_ui/templates/change-response-status.html#L59 *]]
+@enduml

--- a/diagrams/case-state.puml
+++ b/diagrams/case-state.puml
@@ -1,0 +1,15 @@
+@startuml
+skinparam state {
+    BackgroundColor HoneyDew
+}
+
+[*] --> SAMPLED_INIT
+[*] --> REPLACEMENT_INIT
+SAMPLED_INIT --> ACTIONABLE : activated [[https://github.com/ONSdigital/rm-case-service/blob/master/src/main/java/uk/gov/ons/ctp/response/casesvc/scheduled/distribution/CaseDistributor.java#L197 *]]
+REPLACEMENT_INIT --> ACTIONABLE : replaced [[https://github.com/ONSdigital/rm-case-service/blob/master/src/main/java/uk/gov/ons/ctp/response/casesvc/scheduled/distribution/CaseDistributor.java#L201 *]]
+ACTIONABLE --> ACTIONABLE : account_created
+ACTIONABLE --> INACTIONABLE : deactivated
+ACTIONABLE --> INACTIONABLE : disabled
+INACTIONABLE --> INACTIONABLE : deactivated
+INACTIONABLE --> INACTIONABLE : disabled
+@enduml


### PR DESCRIPTION
# Motivation and Context
Added state transition diagrams for case and case group plus makefile to build svgs

# What has changed
No code has been changed but a Makefile has been added

# How to test?
```
make diagrams
/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome diagrams/case-state.svg
/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome diagrams/case-group-state.svg
```
Ensure diagrams can be viewed
