### PR TITLE
Updated dependencies to fix failing acceptance tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,19 +30,19 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.product</groupId>
       <artifactId>samplesvc-api</artifactId>
-      <version>10.49.1</version>
+      <version>10.49.15</version>
     </dependency>
 
     <dependency>
       <groupId>uk.gov.ons.ctp.product</groupId>
       <artifactId>actionsvc-api</artifactId>
-      <version>10.49.0</version>
+      <version>10.49.14</version>
     </dependency>
 
     <dependency>
       <groupId>uk.gov.ons.ctp.product</groupId>
       <artifactId>casesvc-api</artifactId>
-      <version>10.49.15</version>
+      <version>10.49.17</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpoint.java
@@ -180,7 +180,7 @@ public final class CaseEndpoint implements CTPEndpoint {
     Case latestCase = casesList.get(casesList.size() - 1);
     List<String> iacs = internetAccessCodeSvcClientService.generateIACs(1);
 
-    SampleUnitBase sampleUnitBase = new SampleUnitBase(caseGroup.getSampleUnitRef(), Character.toString('B'),
+    SampleUnitBase sampleUnitBase = new SampleUnitBase(UUID.randomUUID().toString(), caseGroup.getSampleUnitRef(), Character.toString('B'),
             caseGroup.getPartyId().toString(), latestCase.getCollectionInstrumentId().toString());
     Case newCase = caseService.generateNewCase(sampleUnitBase, caseGroup, iacs.get(0), latestCase.getActionPlanId());
     log.info("Successfully created new case {}", newCase.getId());


### PR DESCRIPTION
# Motivation and Context
The acceptance tests are currently failing on account of case groups not being created.  Case groups are not being created as the case service is being passed a message with an additional field. This PR updates the message XML definition to allow these messages to be processed.

# What has changed
The dependencies on casesvc-api, actionsvc-api and samplesvc-api have been updated to the latest.  Additionally a random UUID is passed to the constructor for SampleUnitBase in the CaseEndpoint.  This may require further work which will be undertaken in a follow up PR (this change is necessary to allow the dependencies to be updated).

# How to test?
- Run acceptance tests
- Ensure the tests get past the line 'Waiting for collection exercise execution process to finish period=201801 survey_id=cb8accda-6118-4d3b-85a3-149e28960c54'

