### PR TITLE
Update EQ_LAUNCH event category to work with B cases

### DIFF
--- a/src/main/resources/database/changelog-master.yml
+++ b/src/main/resources/database/changelog-master.yml
@@ -47,3 +47,6 @@ databaseChangeLog:
 
   - include:
       file: database/changes/release-10.56.0/changelog.yml
+
+  - include:
+        file: database/changes/release-10.57.0/changelog.yml

--- a/src/main/resources/database/changes/release-10.57.0/changelog.yml
+++ b/src/main/resources/database/changes/release-10.57.0/changelog.yml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+
+  - changeSet:
+      id: 10.57.0-1
+      author: Gemma Irving
+      changes:
+        - sqlFile:
+            comment: Update EQ_LAUNCH category to work with B cases
+            path: update_eq_launch_event_to_include_b_case.sql
+            relativeToChangelogFile: true
+            splitStatements: false

--- a/src/main/resources/database/changes/release-10.57.0/update_eq_launch_event_to_include_b_case.sql
+++ b/src/main/resources/database/changes/release-10.57.0/update_eq_launch_event_to_include_b_case.sql
@@ -1,0 +1,3 @@
+UPDATE casesvc.category
+SET oldcasesampleunittypes = 'B,BI'
+WHERE categorypk = 'EQ_LAUNCH';


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This change is required to allow frontstage to not use BI cases anymore and for the EQ Launch event to be triggered against the B case.

# What has changed
<!--- What code changes has been made -->
Added database changes to update EQ_Launch event category so can be used with B and BI.
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
Ran changes in frontstage. Attempted to access EQ survey.
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
[Trello] https://trello.com/c/PLkePSlW
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
