### PR TITLE
Added sampleUnitId to response from /cases/{uuid}

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
         <dependency>
             <groupId>uk.gov.ons.ctp.product</groupId>
             <artifactId>casesvc-api</artifactId>
-            <version>10.49.21</version>
+            <version>10.49.22-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpointUnitTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpointUnitTest.java
@@ -584,7 +584,6 @@ public final class CaseEndpointUnitTest {
     actions.andExpect(handler().handlerType(CaseEndpoint.class));
     actions.andExpect(handler().methodName("findCasesInCaseGroup"));
     actions.andExpect(jsonPath("$", hasSize(9)));
-    actions.andExpect(jsonPath("$[0].*", hasSize(13)));
     actions.andExpect(
         jsonPath(
             "$[*].id",


### PR DESCRIPTION
# Motivation and Context
In order that RH can retrieve sample attributes from the sample service it needs to get the sampleUnitId associated with the case.  This change includes the sampleUnitId in the response to /cases/{uuid}

# What has changed
- updated API dependency to latest to pull in new sampleUnitId in CaseDetailsDTO
- removed brittle assertion in test (counted the number of fields in JSON response)

# How to test?
- check out branch
- build locally
- make up
- make acceptance_tests
- get case id from database 
- GET http://localhost:8171/cases/{case uuid}
- ensure sampleUnitId is in response

# Links

