### PR TITLE
Add end point to get cases by sampleUnitId

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpoint.java
@@ -112,6 +112,7 @@ public final class CaseEndpoint implements CTPEndpoint {
    * @param iac flag used to return or not the iac
    * @return the cases found
    */
+  @Deprecated // See findCases(sampleUnitId, partyId)
   @RequestMapping(value = "/partyid/{partyId}", method = RequestMethod.GET)
   public ResponseEntity<List<CaseDetailsDTO>> findCasesByPartyId(
       @PathVariable("partyId") final UUID partyId,
@@ -155,13 +156,11 @@ public final class CaseEndpoint implements CTPEndpoint {
   }
 
   private List<Case> getCases(Example<Case> exampleCase) {
-    // Limit to max 100 cases
-    PageRequest paging = new PageRequest(0, 100);
     boolean emptyRequest = exampleCase.getProbe().equals(new Case());
     if (emptyRequest) {
-      return caseRepository.findAll(paging).getContent();
+      return caseRepository.findAll();
     } else {
-      return caseRepository.findAll(exampleCase, paging).getContent();
+      return caseRepository.findAll(exampleCase);
     }
   }
 

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImpl.java
@@ -154,7 +154,7 @@ public class CaseServiceImpl implements CaseService {
   public CaseNotification prepareCaseNotification(Case caze, CaseDTO.CaseEvent transitionEvent) {
     CaseGroup caseGroup = caseGroupRepo.findOne(caze.getCaseGroupFK());
     return new CaseNotification(
-        caze.getSampleUnitId().toString(),
+        Objects.toString(caze.getSampleUnitId(), null),
         caze.getId().toString(),
         caze.getActionPlanId().toString(),
         caseGroup.getCollectionExerciseId().toString(),

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpointUnitTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpointUnitTest.java
@@ -1,32 +1,5 @@
 package uk.gov.ons.ctp.response.casesvc.endpoint;
 
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.Is.isA;
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.handler;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static uk.gov.ons.ctp.common.MvcHelper.getJson;
-import static uk.gov.ons.ctp.common.MvcHelper.postJson;
-import static uk.gov.ons.ctp.common.utility.MockMvcControllerAdviceHelper.mockAdviceFor;
-import static uk.gov.ons.ctp.response.casesvc.endpoint.CaseEndpoint.CATEGORY_ACCESS_CODE_AUTHENTICATION_ATTEMPT_NOT_FOUND;
-import static uk.gov.ons.ctp.response.casesvc.endpoint.CaseEndpoint.ERRORMSG_CASENOTFOUND;
-import static uk.gov.ons.ctp.response.casesvc.utility.Constants.SYSTEM;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
 import ma.glasnost.orika.MapperFacade;
 import org.junit.Before;
 import org.junit.Test;
@@ -36,9 +9,6 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 import org.springframework.data.domain.Example;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -65,6 +35,33 @@ import uk.gov.ons.ctp.response.casesvc.service.CaseGroupService;
 import uk.gov.ons.ctp.response.casesvc.service.CaseService;
 import uk.gov.ons.ctp.response.casesvc.service.CategoryService;
 import uk.gov.ons.ctp.response.casesvc.service.InternetAccessCodeSvcClientService;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.Is.isA;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.handler;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.ons.ctp.common.MvcHelper.getJson;
+import static uk.gov.ons.ctp.common.MvcHelper.postJson;
+import static uk.gov.ons.ctp.common.utility.MockMvcControllerAdviceHelper.mockAdviceFor;
+import static uk.gov.ons.ctp.response.casesvc.endpoint.CaseEndpoint.CATEGORY_ACCESS_CODE_AUTHENTICATION_ATTEMPT_NOT_FOUND;
+import static uk.gov.ons.ctp.response.casesvc.endpoint.CaseEndpoint.ERRORMSG_CASENOTFOUND;
+import static uk.gov.ons.ctp.response.casesvc.utility.Constants.SYSTEM;
 
 /** Case Endpoint Unit tests */
 public final class CaseEndpointUnitTest {
@@ -820,12 +817,10 @@ public final class CaseEndpointUnitTest {
   @Test
   public void getCasesByPartyId() throws Exception {
     // Given
-    PageRequest pageRequest = new PageRequest(0, 100);
     UUID partyId = UUID.randomUUID();
     ArgumentCaptor<Example> captor = ArgumentCaptor.forClass(Example.class);
-    when(caseRepository.findAll(captor.capture(), eq(pageRequest)))
-        .thenReturn(
-            new PageImpl<>(Collections.singletonList(Case.builder().partyId(partyId).build())));
+    when(caseRepository.findAll(captor.capture()))
+        .thenReturn(Collections.singletonList(Case.builder().partyId(partyId).build()));
 
     // When
     ResultActions actions = mockMvc.perform(getJson("/cases").param("partyId", partyId.toString()));
@@ -839,13 +834,10 @@ public final class CaseEndpointUnitTest {
   @Test
   public void getCasesBySampleUnitId() throws Exception {
     // Given
-    PageRequest pageRequest = new PageRequest(0, 100);
     UUID sampleUnitId = UUID.randomUUID();
     ArgumentCaptor<Example> captor = ArgumentCaptor.forClass(Example.class);
-    when(caseRepository.findAll(captor.capture(), eq(pageRequest)))
-        .thenReturn(
-            new PageImpl<>(
-                Collections.singletonList(Case.builder().sampleUnitId(sampleUnitId).build())));
+    when(caseRepository.findAll(captor.capture()))
+        .thenReturn(Collections.singletonList(Case.builder().sampleUnitId(sampleUnitId).build()));
 
     // When
     ResultActions actions =
@@ -862,13 +854,10 @@ public final class CaseEndpointUnitTest {
   @Test
   public void getCasesNoParams() throws Exception {
     // Given
-    PageRequest pageRequest = new PageRequest(0, 100);
     UUID sampleUnitId = UUID.randomUUID();
     ArgumentCaptor<Example> captor = ArgumentCaptor.forClass(Example.class);
-    when(caseRepository.findAll(pageRequest))
-        .thenReturn(
-            new PageImpl<>(
-                Collections.singletonList(Case.builder().sampleUnitId(sampleUnitId).build())));
+    when(caseRepository.findAll())
+        .thenReturn(Collections.singletonList(Case.builder().sampleUnitId(sampleUnitId).build()));
 
     // When
     ResultActions actions = mockMvc.perform(getJson("/cases"));
@@ -880,14 +869,33 @@ public final class CaseEndpointUnitTest {
   }
 
   @Test
+  public void getCasesAllParams() throws Exception {
+    // Given
+    UUID sampleUnitId = UUID.randomUUID();
+    UUID partyId = UUID.randomUUID();
+    ArgumentCaptor<Example> captor = ArgumentCaptor.forClass(Example.class);
+    when(caseRepository.findAll())
+        .thenReturn(
+            Collections.singletonList(
+                Case.builder().sampleUnitId(sampleUnitId).partyId(partyId).build()));
+
+    // When
+    ResultActions actions = mockMvc.perform(getJson("/cases"));
+
+    // Then
+    actions
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].partyId", is(partyId.toString())))
+        .andExpect(jsonPath("$[0].sampleUnitId", is(sampleUnitId.toString())));
+  }
+
+  @Test
   public void getCasesAndCaseGroups() throws Exception {
     // Given
     int caseGroupFK = 1;
     UUID partyId = UUID.randomUUID();
-    when(caseRepository.findAll(any(Pageable.class)))
-        .thenReturn(
-            new PageImpl<>(
-                Collections.singletonList(Case.builder().caseGroupFK(caseGroupFK).build())));
+    when(caseRepository.findAll())
+        .thenReturn(Collections.singletonList(Case.builder().caseGroupFK(caseGroupFK).build()));
     when(caseGroupService.findCaseGroupByCaseGroupPK(caseGroupFK))
         .thenReturn(CaseGroup.builder().partyId(partyId).build());
 


### PR DESCRIPTION
# Motivation and Context
Add end point to get cases by partyId or sampleUnitId by params. The only use case of this at the moment is in tests to be able to get IAC codes for parties or samples. This will stop us needing to query for the IAC code.

# What has changed
New GET api under `/cases`

# How to test?
1. Run unit tests
2. hit api `/cases?partyId=<uuid>`

# Links
https://trello.com/c/SwkUMf9O/99-dev-task-7-ext-access-eq-social-survey-rh
