### PR TITLE
make 'H' cases allowable for OFFLINE_RESPONSE_PROCESSED case event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ plantuml.jar
 
 # Database
 *.rdb
+
+.floo
+.flooignore

--- a/pom.xml
+++ b/pom.xml
@@ -319,13 +319,13 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>2.18.1</version>
                 <executions>
-                <execution>
-                    <goals>
-                    <goal>integration-test</goal>
-                    <goal>verify</goal>
-                    </goals>
-                    <phase>integration-test</phase>
-                </execution>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                        <phase>integration-test</phase>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>

--- a/src/main/resources/database/changelog-master.yml
+++ b/src/main/resources/database/changelog-master.yml
@@ -75,3 +75,6 @@ databaseChangeLog:
   - include:
       file: database/changes/release-12/changelog.yml
 
+  - include:
+      file: database/changes/release-13/changelog.yml
+

--- a/src/main/resources/database/changes/release-13/add_H_cases_to_OFFLINE_RESPONSE_PROCESSED_category.sql
+++ b/src/main/resources/database/changes/release-13/add_H_cases_to_OFFLINE_RESPONSE_PROCESSED_category.sql
@@ -1,3 +1,3 @@
 UPDATE casesvc.category
-SET oldcasesampleunittypes = 'H,'||oldcasesampleunittypes
+SET oldcasesampleunittypes = 'BI,H'
 WHERE categorypk = 'OFFLINE_RESPONSE_PROCESSED'

--- a/src/main/resources/database/changes/release-13/add_H_cases_to_OFFLINE_RESPONSE_PROCESSED_category.sql
+++ b/src/main/resources/database/changes/release-13/add_H_cases_to_OFFLINE_RESPONSE_PROCESSED_category.sql
@@ -1,0 +1,3 @@
+UPDATE casesvc.category
+SET oldcasesampleunittypes = 'H,'||oldcasesampleunittypes
+WHERE categorypk = 'OFFLINE_RESPONSE_PROCESSED'

--- a/src/main/resources/database/changes/release-13/changelog.yml
+++ b/src/main/resources/database/changes/release-13/changelog.yml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+   - changeSet:
+      id: 13-1
+      author: David Mort
+      changes:
+        - sqlFile:
+            comment: Remove DISABLE_RESPONDENT_ENROLMENT category newcasesampleunittype
+            comment: Add H cases to the oldsampleunittype column for the OFFLINE_RESPONSE_PROCESSED category
+            path: add_H_cases_to_OFFLINE_RESPONSE_PROCESSED_category.sql
+            relativeToChangelogFile: true
+            splitStatements: false

--- a/src/main/resources/database/changes/release-13/changelog.yml
+++ b/src/main/resources/database/changes/release-13/changelog.yml
@@ -4,7 +4,6 @@ databaseChangeLog:
       author: David Mort
       changes:
         - sqlFile:
-            comment: Remove DISABLE_RESPONDENT_ENROLMENT category newcasesampleunittype
             comment: Add H cases to the oldsampleunittype column for the OFFLINE_RESPONSE_PROCESSED category
             path: add_H_cases_to_OFFLINE_RESPONSE_PROCESSED_category.sql
             relativeToChangelogFile: true

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/CaseCreator.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/CaseCreator.java
@@ -1,0 +1,114 @@
+package uk.gov.ons.ctp.response.casesvc;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.UUID;
+import java.util.concurrent.BlockingQueue;
+import javax.xml.bind.JAXBContext;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.stereotype.Component;
+import uk.gov.ons.ctp.common.utility.Mapzer;
+import uk.gov.ons.ctp.response.casesvc.config.AppConfig;
+import uk.gov.ons.ctp.response.casesvc.message.notification.CaseNotification;
+import uk.gov.ons.ctp.response.casesvc.message.sampleunitnotification.SampleUnitParent;
+import uk.gov.ons.tools.rabbit.Rabbitmq;
+import uk.gov.ons.tools.rabbit.SimpleMessageBase;
+import uk.gov.ons.tools.rabbit.SimpleMessageListener;
+import uk.gov.ons.tools.rabbit.SimpleMessageSender;
+
+@Component
+@Slf4j
+public class CaseCreator {
+
+  @Autowired private AppConfig appConfig;
+  @Autowired private ResourceLoader resourceLoader;
+
+  /**
+   * Sends a sample unit in a message so that casesvc creates a case, then waits for a message on
+   * the case lifecycle queue which confirms case creation
+   *
+   * @return a new CaseNotification
+   */
+  public CaseNotification sendSampleUnit(
+      String sampleUnitRef, String sampleUnitType, UUID sampleUnitId) throws Exception {
+    createIACStub();
+
+    SampleUnitParent sampleUnit = new SampleUnitParent();
+    sampleUnit.setCollectionExerciseId(UUID.randomUUID().toString());
+    sampleUnit.setId(sampleUnitId.toString());
+    sampleUnit.setActionPlanId(UUID.randomUUID().toString());
+    sampleUnit.setSampleUnitRef(sampleUnitRef);
+    sampleUnit.setCollectionInstrumentId(UUID.randomUUID().toString());
+    sampleUnit.setPartyId(UUID.randomUUID().toString());
+    sampleUnit.setSampleUnitType(sampleUnitType);
+
+    JAXBContext jaxbContext = JAXBContext.newInstance(SampleUnitParent.class);
+    String xml =
+        new Mapzer(resourceLoader)
+            .convertObjectToXml(
+                jaxbContext, sampleUnit, "casesvc/xsd/inbound/SampleUnitNotification.xsd");
+
+    BlockingQueue<String> queue =
+        getMessageListener()
+            .listen(
+                SimpleMessageBase.ExchangeType.Direct,
+                "case-outbound-exchange",
+                "Case.LifecycleEvents.binding");
+    getMessageSender().sendMessage("collection-inbound-exchange", "Case.CaseDelivery.binding", xml);
+
+    String message = waitForNotification(queue);
+
+    jaxbContext = JAXBContext.newInstance(CaseNotification.class);
+    return (CaseNotification)
+        jaxbContext.createUnmarshaller().unmarshal(new ByteArrayInputStream(message.getBytes()));
+  }
+
+  private String waitForNotification(BlockingQueue<String> queue) throws Exception {
+    String message = queue.take();
+    log.info("message = " + message);
+    assertNotNull("Timeout waiting for message to arrive in Case.LifecycleEvents", message);
+
+    return message;
+  }
+
+  /**
+   * Creates a new SimpleMessageSender based on the config in AppConfig
+   *
+   * @return a new SimpleMessageSender
+   */
+  private SimpleMessageSender getMessageSender() {
+    Rabbitmq config = this.appConfig.getRabbitmq();
+
+    return new SimpleMessageSender(
+        config.getHost(), config.getPort(), config.getUsername(), config.getPassword());
+  }
+
+  /**
+   * Creates a new SimpleMessageListener based on the config in AppConfig
+   *
+   * @return a new SimpleMessageListener
+   */
+  private SimpleMessageListener getMessageListener() {
+    Rabbitmq config = this.appConfig.getRabbitmq();
+
+    return new SimpleMessageListener(
+        config.getHost(), config.getPort(), config.getUsername(), config.getPassword());
+  }
+
+  private void createIACStub() throws IOException {
+    stubFor(
+        post(urlPathEqualTo("/iacs"))
+            .willReturn(
+                aResponse()
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("[\"grtt7x2nhygg\"]")));
+  }
+}

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpointIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpointIT.java
@@ -1,11 +1,7 @@
 package uk.gov.ons.ctp.response.casesvc.endpoint;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.post;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static org.assertj.core.api.Java6Assertions.assertThat;
-import static org.junit.Assert.assertNotNull;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
@@ -13,57 +9,40 @@ import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
 import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.Unirest;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.util.UUID;
 import java.util.concurrent.BlockingQueue;
 import javax.xml.bind.JAXBContext;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.embedded.LocalServerPort;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.core.io.ResourceLoader;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.rules.SpringClassRule;
-import org.springframework.test.context.junit4.rules.SpringMethodRule;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import uk.gov.ons.ctp.common.UnirestInitialiser;
-import uk.gov.ons.ctp.common.utility.Mapzer;
-import uk.gov.ons.ctp.response.casesvc.config.AppConfig;
+import uk.gov.ons.ctp.response.casesvc.CaseCreator;
 import uk.gov.ons.ctp.response.casesvc.message.notification.CaseNotification;
-import uk.gov.ons.ctp.response.casesvc.message.sampleunitnotification.SampleUnitParent;
 import uk.gov.ons.ctp.response.casesvc.representation.CaseDetailsDTO;
 import uk.gov.ons.ctp.response.casesvc.representation.CaseEventCreationRequestDTO;
 import uk.gov.ons.ctp.response.casesvc.representation.CaseGroupStatus;
 import uk.gov.ons.ctp.response.casesvc.representation.CategoryDTO.CategoryName;
 import uk.gov.ons.ctp.response.casesvc.representation.CreatedCaseEventDTO;
-import uk.gov.ons.tools.rabbit.Rabbitmq;
-import uk.gov.ons.tools.rabbit.SimpleMessageBase;
-import uk.gov.ons.tools.rabbit.SimpleMessageListener;
-import uk.gov.ons.tools.rabbit.SimpleMessageSender;
 
 @ContextConfiguration
 @ActiveProfiles("test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@RunWith(SpringJUnit4ClassRunner.class)
 public class CaseEndpointIT {
   private static final Logger log = LoggerFactory.getLogger(CaseEndpointIT.class);
 
-  @ClassRule public static final SpringClassRule SPRING_CLASS_RULE = new SpringClassRule();
-
-  @Rule public final SpringMethodRule springMethodRule = new SpringMethodRule();
-
   @Rule public WireMockRule wireMockRule = new WireMockRule(options().port(18002));
-
-  @Autowired private ResourceLoader resourceLoader;
 
   @LocalServerPort private int port;
 
-  @Autowired private ObjectMapper mapper;
-
-  @Autowired private AppConfig appConfig;
+  @Autowired private CaseCreator caseCreator;
 
   @BeforeClass
   public static void setUp() {
@@ -75,7 +54,7 @@ public class CaseEndpointIT {
   public void ensureSampleUnitIdReceived() throws Exception {
     UUID sampleUnitId = UUID.randomUUID();
 
-    CaseNotification caseNotification = sendSampleUnit("LMS0001", "H", sampleUnitId);
+    CaseNotification caseNotification = caseCreator.sendSampleUnit("LMS0001", "H", sampleUnitId);
 
     assertThat(caseNotification.getSampleUnitId()).isEqualTo(sampleUnitId.toString());
   }
@@ -84,7 +63,8 @@ public class CaseEndpointIT {
   public void testCreateSocialCaseEvents() throws Exception {
 
     // Given
-    CaseNotification caseNotification = sendSampleUnit("LMS0002", "H", UUID.randomUUID());
+    CaseNotification caseNotification =
+        caseCreator.sendSampleUnit("LMS0002", "H", UUID.randomUUID());
 
     String caseID = caseNotification.getCaseId();
     CaseEventCreationRequestDTO caseEventCreationRequestDTO =
@@ -107,7 +87,7 @@ public class CaseEndpointIT {
   public void ensureCaseReturnedBySampleUnitId() throws Exception {
 
     UUID sampleUnitId = UUID.randomUUID();
-    CaseNotification caseNotif = sendSampleUnit("LMS0003", "H", sampleUnitId);
+    CaseNotification caseNotif = caseCreator.sendSampleUnit("LMS0003", "H", sampleUnitId);
 
     UUID caseId = UUID.fromString(caseNotif.getCaseId());
 
@@ -126,14 +106,13 @@ public class CaseEndpointIT {
   /**
    * Test Collection Instrument downloaded case event works with B cases, and case group status has
    * transitioned to InProgress.
-   *
-   * @throws Exception
    */
   @Test
   public void testCreateCollectionInstrumentDownloadedCaseEventWithBCaseSuccess() throws Exception {
 
     // Given
-    CaseNotification caseNotification = sendSampleUnit("BS12345", "B", UUID.randomUUID());
+    CaseNotification caseNotification =
+        caseCreator.sendSampleUnit("BS12345", "B", UUID.randomUUID());
 
     String caseID = caseNotification.getCaseId();
     CaseEventCreationRequestDTO caseEventCreationRequestDTO =
@@ -168,14 +147,13 @@ public class CaseEndpointIT {
   /**
    * Test Collection Instrument downloaded case event works with B cases, and case group status has
    * not transitioned to InProgress.
-   *
-   * @throws Exception
    */
   @Test
   public void testCreateCollectionInstrumentErrorCaseEventWithBCaseSuccess() throws Exception {
 
     // Given
-    CaseNotification caseNotification = sendSampleUnit("BS12345", "B", UUID.randomUUID());
+    CaseNotification caseNotification =
+        caseCreator.sendSampleUnit("BS12345", "B", UUID.randomUUID());
 
     String caseID = caseNotification.getCaseId();
     CaseEventCreationRequestDTO caseEventCreationRequestDTO =
@@ -210,14 +188,13 @@ public class CaseEndpointIT {
   /**
    * Test Successful response upload case event works with B cases, and case group status has
    * transitioned to Complete.
-   *
-   * @throws Exception
    */
   @Test
   public void testCreateSuccessfulResponseUploadCaseEventWithBCaseSuccess() throws Exception {
 
     // Given
-    CaseNotification caseNotification = sendSampleUnit("BS12345", "B", UUID.randomUUID());
+    CaseNotification caseNotification =
+        caseCreator.sendSampleUnit("BS12345", "B", UUID.randomUUID());
 
     String caseID = caseNotification.getCaseId();
     CaseEventCreationRequestDTO caseEventCreationRequestDTO =
@@ -252,14 +229,13 @@ public class CaseEndpointIT {
   /**
    * Test Unsuccessful Response Upload case event works with B cases, and case group status has not
    * transitioned to Complete.
-   *
-   * @throws Exception
    */
   @Test
   public void testCreateUnsuccessfulResponseUploadCaseEventWithBCaseSuccess() throws Exception {
 
     // Given
-    CaseNotification caseNotification = sendSampleUnit("BS12345", "B", UUID.randomUUID());
+    CaseNotification caseNotification =
+        caseCreator.sendSampleUnit("BS12345", "B", UUID.randomUUID());
 
     String caseID = caseNotification.getCaseId();
     CaseEventCreationRequestDTO caseEventCreationRequestDTO =
@@ -289,90 +265,5 @@ public class CaseEndpointIT {
     assertThat(createdCaseResponse.getStatus()).isEqualTo(201);
     assertThat(affectedCase.getCaseGroup().getCaseGroupStatus())
         .isNotEqualTo(CaseGroupStatus.COMPLETE);
-  }
-
-  /**
-   * Creates a new SimpleMessageSender based on the config in AppConfig
-   *
-   * @return a new SimpleMessageSender
-   */
-  private SimpleMessageSender getMessageSender() {
-    Rabbitmq config = this.appConfig.getRabbitmq();
-
-    return new SimpleMessageSender(
-        config.getHost(), config.getPort(), config.getUsername(), config.getPassword());
-  }
-
-  /**
-   * Creates a new SimpleMessageListener based on the config in AppConfig
-   *
-   * @return a new SimpleMessageListener
-   */
-  private SimpleMessageListener getMessageListener() {
-    Rabbitmq config = this.appConfig.getRabbitmq();
-
-    return new SimpleMessageListener(
-        config.getHost(), config.getPort(), config.getUsername(), config.getPassword());
-  }
-
-  private void createIACStub() throws IOException {
-    this.wireMockRule.stubFor(
-        post(urlPathEqualTo("/iacs"))
-            .willReturn(
-                aResponse()
-                    .withHeader("Content-Type", "application/json")
-                    .withBody("[\"grtt7x2nhygg\"]")));
-  }
-
-  /**
-   * Sends a sample unit in a message so that casesvc creates a case, then waits for a message on
-   * the case lifecycle queue which confirms case creation
-   *
-   * @return a new CaseNotification
-   */
-  private CaseNotification sendSampleUnit(
-      String sampleUnitRef, String sampleUnitType, UUID sampleUnitId) throws Exception {
-    createIACStub();
-
-    SimpleMessageSender sender = getMessageSender();
-
-    SampleUnitParent sampleUnit = new SampleUnitParent();
-    sampleUnit.setCollectionExerciseId(UUID.randomUUID().toString());
-    sampleUnit.setId(sampleUnitId.toString());
-    sampleUnit.setActionPlanId(UUID.randomUUID().toString());
-    sampleUnit.setSampleUnitRef(sampleUnitRef);
-    sampleUnit.setCollectionInstrumentId(UUID.randomUUID().toString());
-    sampleUnit.setPartyId(UUID.randomUUID().toString());
-    sampleUnit.setSampleUnitType(sampleUnitType);
-
-    JAXBContext jaxbContext = JAXBContext.newInstance(SampleUnitParent.class);
-    String xml =
-        new Mapzer(resourceLoader)
-            .convertObjectToXml(
-                jaxbContext, sampleUnit, "casesvc/xsd/inbound/SampleUnitNotification.xsd");
-
-    sender.sendMessage("collection-inbound-exchange", "Case.CaseDelivery.binding", xml);
-
-    String message = waitForNotification();
-
-    jaxbContext = JAXBContext.newInstance(CaseNotification.class);
-    return (CaseNotification)
-        jaxbContext.createUnmarshaller().unmarshal(new ByteArrayInputStream(message.getBytes()));
-  }
-
-  private String waitForNotification() throws Exception {
-
-    SimpleMessageListener listener = getMessageListener();
-    BlockingQueue<String> queue =
-        listener.listen(
-            SimpleMessageBase.ExchangeType.Direct,
-            "case-outbound-exchange",
-            "Case.LifecycleEvents.binding");
-
-    String message = queue.take();
-    log.info("message = " + message);
-    assertNotNull("Timeout waiting for message to arrive in Case.LifecycleEvents", message);
-
-    return message;
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpointIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpointIT.java
@@ -10,8 +10,6 @@ import com.godaddy.logging.LoggerFactory;
 import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.Unirest;
 import java.util.UUID;
-import java.util.concurrent.BlockingQueue;
-import javax.xml.bind.JAXBContext;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/message/CaseReceiptReceiverImplIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/message/CaseReceiptReceiverImplIT.java
@@ -1,0 +1,107 @@
+package uk.gov.ons.ctp.response.casesvc.message;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.junit.Assert.assertEquals;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.mashape.unirest.http.HttpResponse;
+import com.mashape.unirest.http.Unirest;
+import com.sun.org.apache.xerces.internal.jaxp.datatype.XMLGregorianCalendarImpl;
+import java.util.GregorianCalendar;
+import java.util.UUID;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.embedded.LocalServerPort;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.support.GenericMessage;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import uk.gov.ons.ctp.common.UnirestInitialiser;
+import uk.gov.ons.ctp.response.casesvc.CaseCreator;
+import uk.gov.ons.ctp.response.casesvc.message.feedback.CaseReceipt;
+import uk.gov.ons.ctp.response.casesvc.message.feedback.InboundChannel;
+import uk.gov.ons.ctp.response.casesvc.message.notification.CaseNotification;
+import uk.gov.ons.ctp.response.casesvc.representation.CaseDetailsDTO;
+import uk.gov.ons.ctp.response.casesvc.representation.CaseEventCreationRequestDTO;
+import uk.gov.ons.ctp.response.casesvc.representation.CaseGroupStatus;
+import uk.gov.ons.ctp.response.casesvc.representation.CategoryDTO;
+import uk.gov.ons.ctp.response.casesvc.representation.CreatedCaseEventDTO;
+
+@ContextConfiguration
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@RunWith(SpringJUnit4ClassRunner.class)
+public class CaseReceiptReceiverImplIT {
+
+  @LocalServerPort private int port;
+
+  @Autowired private MessageChannel caseReceiptTransformed;
+
+  @Autowired private CaseCreator caseCreator;
+
+  @Rule public WireMockRule wireMockRule = new WireMockRule(options().port(18002));
+
+  @BeforeClass
+  public static void setUp() {
+    ObjectMapper value = new ObjectMapper();
+    UnirestInitialiser.initialise(value);
+  }
+
+  @Test
+  public void socialCaseShouldReceipt() throws Exception {
+    // Given
+    UUID sampleUnitId = UUID.randomUUID();
+    CaseNotification caseNotif = caseCreator.sendSampleUnit("LMS0003", "H", sampleUnitId);
+    startCase(caseNotif.getCaseId());
+    XMLGregorianCalendarImpl now = new XMLGregorianCalendarImpl(new GregorianCalendar());
+    CaseReceipt caseReceipt =
+        new CaseReceipt("caseRef", caseNotif.getCaseId(), InboundChannel.OFFLINE, now);
+    Message<CaseReceipt> message = new GenericMessage<>(caseReceipt);
+    stubDisableIAC();
+
+    // When
+    caseReceiptTransformed.send(message);
+
+    // Then
+    HttpResponse<CaseDetailsDTO[]> casesResponse =
+        Unirest.get(String.format("http://localhost:%d/cases/sampleunitids", port))
+            .basicAuth("admin", "secret")
+            .queryString("sampleUnitId", sampleUnitId)
+            .header("Content-Type", "application/json")
+            .asObject(CaseDetailsDTO[].class);
+    CaseDetailsDTO caseDetailsDTO = casesResponse.getBody()[0];
+    assertEquals(CaseGroupStatus.COMPLETE, caseDetailsDTO.getCaseGroup().getCaseGroupStatus());
+    assertEquals(1, caseDetailsDTO.getResponses().size());
+    assertEquals("OFFLINE", caseDetailsDTO.getResponses().get(0).getInboundChannel());
+  }
+
+  private void stubDisableIAC() {
+    stubFor(
+        put(urlPathEqualTo("/iacs/grtt7x2nhygg"))
+            .willReturn(
+                aResponse().withHeader("Content-Type", "application/json").withStatus(200)));
+  }
+
+  private void startCase(String caseId) throws Exception {
+    CaseEventCreationRequestDTO caseEvent = new CaseEventCreationRequestDTO();
+    caseEvent.setCategory(CategoryDTO.CategoryName.EQ_LAUNCH);
+    caseEvent.setCreatedBy("test");
+    caseEvent.setDescription("test");
+    Unirest.post(String.format("http://localhost:%d/cases/%s/events", port, caseId))
+        .basicAuth("admin", "secret")
+        .header("Content-Type", "application/json")
+        .body(caseEvent)
+        .asObject(CreatedCaseEventDTO.class);
+  }
+}


### PR DESCRIPTION
# Motivation and Context
Currently when surveys responses/cases are receipted a case event is created of the OFFLINE_RESPONSE_PROCESSED category, only 'BI' cases are currently allowed for this. We need to make 'H' cases receipt-able within the current process by allowing OFFLINE_RESPONSE_PROCESSED case events for 'H' cases.

# What has changed
Add a DB script to add 'H' to the oldsampleunittype column for the OFFLINE_RESPONSE_PROCESSED in the category table

# How to test?
make a POST request to the receipts endpoint in rm-sdx-gateway with a caseId of a H case 

to test in the docker dev environment:
- spin up all the services
- create social data by running the setup-and-execute make target in social folder in rm-tools https://github.com/ONSdigital/rm-tools/tree/master/social-test-setup
- find an actionable 'H' case 
- make a POST request curl -X POST -d '{"caseId":"<caseId>"}' http://0.0.0.0:8191/receipts -H '<authorization details>' -H 'Content-Type:application/json'
- tail the case service logs and you should see a log line that looks like this: "Successfully created case event, casePK=2, category=OFFLINE_RESPONSE_PROCESSED, subCategory=null, createdBy=SYSTEM"

