### PR TITLE
Roll out Godaddy logger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>uk.gov.ons.ctp.product</groupId>
         <artifactId>rm-common-config</artifactId>
-        <version>10.49.12</version>
+        <version>10.49.13</version>
     </parent>
 
     <profiles>
@@ -207,6 +207,10 @@
             <artifactId>logstash-logback-encoder</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.godaddy</groupId>
+            <artifactId>logging</artifactId>
+        </dependency>
         <!-- Third party end -->
 
         <!-- Testing -->

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/CaseSvcApplication.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/CaseSvcApplication.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.ctp.response.casesvc;
 
+import com.godaddy.logging.LoggingConfigs;
 import net.sourceforge.cobertura.CoverageIgnore;
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
@@ -71,6 +72,8 @@ public class CaseSvcApplication {
    * @param args runtime command line args
    */
   public static void main(final String[] args) {
+    LoggingConfigs.setCurrent(LoggingConfigs.getCurrent().useJson());
+
     SpringApplication.run(CaseSvcApplication.class, args);
   }
 

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpoint.java
@@ -1,5 +1,7 @@
 package uk.gov.ons.ctp.response.casesvc.endpoint;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
@@ -7,7 +9,6 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import javax.validation.Valid;
-import lombok.extern.slf4j.Slf4j;
 import ma.glasnost.orika.MapperFacade;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -46,8 +47,8 @@ import uk.gov.ons.ctp.response.casesvc.utility.Constants;
 /** The REST endpoint controller for CaseSvc Cases */
 @RestController
 @RequestMapping(value = "/cases", produces = "application/json")
-@Slf4j
 public final class CaseEndpoint implements CTPEndpoint {
+  private static final Logger log = LoggerFactory.getLogger(CaseEndpoint.class);
 
   public static final String CATEGORY_ACCESS_CODE_AUTHENTICATION_ATTEMPT_NOT_FOUND =
       "Category ACCESS_CODE_AUTHENTICATION_ATTEMPT does not exist";

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseGroupEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseGroupEndpoint.java
@@ -1,11 +1,12 @@
 package uk.gov.ons.ctp.response.casesvc.endpoint;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import lombok.extern.slf4j.Slf4j;
 import ma.glasnost.orika.MapperFacade;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -34,8 +35,8 @@ import uk.gov.ons.ctp.response.casesvc.utility.Constants;
 /** The REST endpoint controller for CaseSvc CaseGroups */
 @RestController
 @RequestMapping(value = "/casegroups", produces = "application/json")
-@Slf4j
 public final class CaseGroupEndpoint implements CTPEndpoint {
+  private static final Logger log = LoggerFactory.getLogger(CaseGroupEndpoint.class);
 
   private CaseGroupService caseGroupService;
   private CaseService caseService;

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/endpoint/CategoryEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/endpoint/CategoryEndpoint.java
@@ -1,8 +1,9 @@
 package uk.gov.ons.ctp.response.casesvc.endpoint;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.util.List;
 import java.util.Optional;
-import lombok.extern.slf4j.Slf4j;
 import ma.glasnost.orika.MapperFacade;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -22,8 +23,9 @@ import uk.gov.ons.ctp.response.casesvc.service.CategoryService;
 /** The REST endpoint controller for Category */
 @RestController
 @RequestMapping(value = "/categories", produces = "application/json")
-@Slf4j
 public final class CategoryEndpoint implements CTPEndpoint {
+  private static final Logger log = LoggerFactory.getLogger(CategoryEndpoint.class);
+
   public static final String ERRORMSG_CATEGORYNOTFOUND = "Category not found for";
 
   @Autowired private CategoryService categoryService;

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/message/impl/CaseCreationReceiverImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/message/impl/CaseCreationReceiverImpl.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.ctp.response.casesvc.message.impl;
 
-import lombok.extern.slf4j.Slf4j;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
@@ -10,8 +11,9 @@ import uk.gov.ons.ctp.response.casesvc.service.CaseService;
 
 /** Receive a new case from the Collection Exercise service. */
 @MessageEndpoint
-@Slf4j
 public class CaseCreationReceiverImpl implements CaseCreationReceiver {
+  private static final Logger log = LoggerFactory.getLogger(CaseCreationReceiverImpl.class);
+
   @Autowired private CaseService caseService;
 
   @Override

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/message/impl/CaseNotificationPublisherImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/message/impl/CaseNotificationPublisherImpl.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.ctp.response.casesvc.message.impl;
 
-import lombok.extern.slf4j.Slf4j;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -12,8 +13,8 @@ import uk.gov.ons.ctp.response.casesvc.message.notification.CaseNotification;
  * Service implementation responsible for publishing case lifecycle events to notification channel
  */
 @MessageEndpoint
-@Slf4j
 public class CaseNotificationPublisherImpl implements CaseNotificationPublisher {
+  private static final Logger log = LoggerFactory.getLogger(CaseNotificationPublisherImpl.class);
 
   @Qualifier("caseNotificationRabbitTemplate")
   @Autowired

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/message/impl/CaseReceiptReceiverImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/message/impl/CaseReceiptReceiverImpl.java
@@ -6,9 +6,10 @@ import static uk.gov.ons.ctp.response.casesvc.representation.CategoryDTO.Categor
 import static uk.gov.ons.ctp.response.casesvc.utility.Constants.QUESTIONNAIRE_RESPONSE;
 import static uk.gov.ons.ctp.response.casesvc.utility.Constants.SYSTEM;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.sql.Timestamp;
 import java.util.UUID;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
@@ -24,9 +25,9 @@ import uk.gov.ons.ctp.response.casesvc.representation.CategoryDTO;
 import uk.gov.ons.ctp.response.casesvc.service.CaseService;
 
 /** The reader of CaseReceipts from queue */
-@Slf4j
 @MessageEndpoint
 public class CaseReceiptReceiverImpl implements CaseReceiptReceiver {
+  private static final Logger log = LoggerFactory.getLogger(CaseReceiptReceiverImpl.class);
 
   private static final String EXISTING_CASE_NOT_FOUND = "No existing case found for caseId %s";
 

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/message/impl/EventPublisherImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/message/impl/EventPublisherImpl.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.ctp.response.casesvc.message.impl;
 
-import lombok.extern.slf4j.Slf4j;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -8,8 +9,8 @@ import org.springframework.integration.annotation.MessageEndpoint;
 import uk.gov.ons.ctp.response.casesvc.message.EventPublisher;
 
 @MessageEndpoint
-@Slf4j
 public class EventPublisherImpl implements EventPublisher {
+  private static final Logger log = LoggerFactory.getLogger(EventPublisherImpl.class);
 
   @Qualifier("amqpTemplate")
   @Autowired

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/scheduled/ReportScheduler.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/scheduled/ReportScheduler.java
@@ -1,8 +1,9 @@
 package uk.gov.ons.ctp.response.casesvc.scheduled;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -15,8 +16,8 @@ import uk.gov.ons.ctp.response.casesvc.service.CaseReportService;
  * The scheduler to trigger reports creation based on a cron expression defined in application.yml
  */
 @Component
-@Slf4j
 public class ReportScheduler {
+  private static final Logger log = LoggerFactory.getLogger(ReportScheduler.class);
 
   private static final String DISTRIBUTED_OBJECT_KEY_REPORT_LATCH = "reportlatch";
   private static final String DISTRIBUTED_OBJECT_KEY_INSTANCE_COUNT = "reportscheduler";

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/scheduled/distribution/CaseDistributionScheduler.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/scheduled/distribution/CaseDistributionScheduler.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.ctp.response.casesvc.scheduled.distribution;
 
-import lombok.extern.slf4j.Slf4j;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import net.sourceforge.cobertura.CoverageIgnore;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.health.Health;
@@ -14,8 +15,8 @@ import org.springframework.stereotype.Component;
  */
 @CoverageIgnore
 @Component
-@Slf4j
 public class CaseDistributionScheduler implements HealthIndicator {
+  private static final Logger log = LoggerFactory.getLogger(CaseDistributionScheduler.class);
 
   @Autowired private CaseDistributor caseDistributorImpl;
 

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/scheduled/distribution/CaseDistributor.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/scheduled/distribution/CaseDistributor.java
@@ -1,10 +1,11 @@
 package uk.gov.ons.ctp.response.casesvc.scheduled.distribution;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import lombok.extern.slf4j.Slf4j;
 import net.sourceforge.cobertura.CoverageIgnore;
 import org.apache.commons.collections.CollectionUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,8 +42,8 @@ import uk.gov.ons.ctp.response.casesvc.service.InternetAccessCodeSvcClientServic
  */
 @CoverageIgnore
 @Component
-@Slf4j
 public class CaseDistributor {
+  private static final Logger log = LoggerFactory.getLogger(CaseDistributor.class);
 
   private static final String CASE_DISTRIBUTOR_LIST_ID = "case";
 

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/ActionSvcClientServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/ActionSvcClientServiceImpl.java
@@ -1,7 +1,8 @@
 package uk.gov.ons.ctp.response.casesvc.service.impl;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.util.UUID;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpEntity;
@@ -15,9 +16,9 @@ import uk.gov.ons.ctp.response.casesvc.config.AppConfig;
 import uk.gov.ons.ctp.response.casesvc.service.ActionSvcClientService;
 
 /** The impl of the service which calls the action service via REST */
-@Slf4j
 @Service
 public class ActionSvcClientServiceImpl implements ActionSvcClientService {
+  private static final Logger log = LoggerFactory.getLogger(ActionSvcClientServiceImpl.class);
 
   @Autowired private AppConfig appConfig;
 

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseGroupAuditServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseGroupAuditServiceImpl.java
@@ -1,7 +1,8 @@
 package uk.gov.ons.ctp.response.casesvc.service.impl;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.util.UUID;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.ons.ctp.common.time.DateTimeUtil;
@@ -11,8 +12,8 @@ import uk.gov.ons.ctp.response.casesvc.domain.repository.CaseGroupStatusAuditRep
 import uk.gov.ons.ctp.response.casesvc.service.CaseGroupAuditService;
 
 @Service
-@Slf4j
 public class CaseGroupAuditServiceImpl implements CaseGroupAuditService {
+  private static final Logger log = LoggerFactory.getLogger(CaseGroupAuditServiceImpl.class);
 
   @Autowired private CaseGroupStatusAuditRepository caseGroupStatusAuditRepository;
 

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseGroupServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseGroupServiceImpl.java
@@ -1,9 +1,10 @@
 package uk.gov.ons.ctp.response.casesvc.service.impl;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -25,8 +26,8 @@ import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExer
  * CaseGroup entity model.
  */
 @Service
-@Slf4j
 public class CaseGroupServiceImpl implements CaseGroupService {
+  private static final Logger log = LoggerFactory.getLogger(CaseGroupServiceImpl.class);
 
   /** Spring Data Repository for CaseGroup entities. */
   @Autowired private CaseGroupRepository caseGroupRepo;

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseReportServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseReportServiceImpl.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.ctp.response.casesvc.service.impl;
 
-import lombok.extern.slf4j.Slf4j;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.ons.ctp.response.casesvc.domain.repository.CaseReportRepository;
@@ -11,8 +12,8 @@ import uk.gov.ons.ctp.response.casesvc.service.CaseReportService;
  * CaseReport entity model.
  */
 @Service
-@Slf4j
 public class CaseReportServiceImpl implements CaseReportService {
+  private static final Logger log = LoggerFactory.getLogger(CaseReportServiceImpl.class);
 
   @Autowired private CaseReportRepository caseReportRepository;
 

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImpl.java
@@ -1,12 +1,13 @@
 package uk.gov.ons.ctp.response.casesvc.service.impl;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections.CollectionUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -52,8 +53,8 @@ import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO.SampleUnitTyp
  * model.
  */
 @Service
-@Slf4j
 public class CaseServiceImpl implements CaseService {
+  private static final Logger log = LoggerFactory.getLogger(CaseServiceImpl.class);
 
   public static final String IAC_OVERUSE_MSG = "More than one case found to be using IAC %s";
   public static final String MISSING_NEW_CASE_MSG = "New Case definition missing for case %s";

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CategoryServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CategoryServiceImpl.java
@@ -1,8 +1,9 @@
 package uk.gov.ons.ctp.response.casesvc.service.impl;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.util.List;
 import java.util.stream.Collectors;
-import lombok.extern.slf4j.Slf4j;
 import net.sourceforge.cobertura.CoverageIgnore;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -18,8 +19,8 @@ import uk.gov.ons.ctp.response.casesvc.service.CategoryService;
  */
 @CoverageIgnore
 @Service
-@Slf4j
 public class CategoryServiceImpl implements CategoryService {
+  private static final Logger log = LoggerFactory.getLogger(CategoryServiceImpl.class);
 
   /** Spring Data Repository for CaseType entities. */
   @Autowired private CategoryRepository categoryRepo;

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CollectionExerciseSvcClientServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CollectionExerciseSvcClientServiceImpl.java
@@ -2,10 +2,11 @@ package uk.gov.ons.ctp.response.casesvc.service.impl;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
-import lombok.extern.slf4j.Slf4j;
 import net.sourceforge.cobertura.CoverageIgnore;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -24,10 +25,11 @@ import uk.gov.ons.ctp.response.casesvc.service.CollectionExerciseSvcClientServic
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO;
 
 /** The service to retrieve a CollectionExercise */
-@Slf4j
 @CoverageIgnore
 @Service
 public class CollectionExerciseSvcClientServiceImpl implements CollectionExerciseSvcClientService {
+  private static final Logger log =
+      LoggerFactory.getLogger(CollectionExerciseSvcClientServiceImpl.class);
 
   @Autowired private AppConfig appConfig;
 

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/InternetAccessCodeSvcClientServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/InternetAccessCodeSvcClientServiceImpl.java
@@ -2,9 +2,10 @@ package uk.gov.ons.ctp.response.casesvc.service.impl;
 
 import static uk.gov.ons.ctp.response.casesvc.utility.Constants.SYSTEM;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.util.Arrays;
 import java.util.List;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpEntity;
@@ -24,9 +25,10 @@ import uk.gov.ons.ctp.response.iac.representation.InternetAccessCodeDTO;
 import uk.gov.ons.ctp.response.iac.representation.UpdateInternetAccessCodeDTO;
 
 /** The impl of the service which calls the IAC service via REST */
-@Slf4j
 @Service
 public class InternetAccessCodeSvcClientServiceImpl implements InternetAccessCodeSvcClientService {
+  private static final Logger log =
+      LoggerFactory.getLogger(InternetAccessCodeSvcClientServiceImpl.class);
 
   private AppConfig appConfig;
   private RestTemplate restTemplate;

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -9,30 +9,49 @@
     value="%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p})  %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}"/>
   <property name="SYSLOG_PATTERN"
     value="${LOG_LEVEL_PATTERN:-%5level} %-40.40logger{39} : %message%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}"/>
+  <property name="ISO8601_DATE_FORMAT" value="yyyy-MM-dd'T'HH:mm:ss'Z'" />
 
-  <appender class="ch.qos.logback.core.ConsoleAppender" name="CLOUD">
+  <appender name="CLOUD" class="ch.qos.logback.core.ConsoleAppender">
     <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
       <providers>
-        <mdc/>
-        <pattern>
-          <pattern>
-            {
-            "created": "%date{ISO8601}",
-            "service": "casesvc",
-            "level": "%level",
-            "event": "%message"
-            }
-          </pattern>
-        </pattern>
+        <timestamp>
+          <timeZone>UTC</timeZone>
+          <pattern>${ISO8601_DATE_FORMAT}</pattern>
+          <fieldName>created</fieldName>
+        </timestamp>
+        <globalCustomFields>
+          <customFields>{"service":"samplesvc"}</customFields>
+        </globalCustomFields>
+        <message>
+          <fieldName>event</fieldName>
+        </message>
+        <loggerName/>
+        <threadName/>
+        <logLevel>
+          <fieldName>level</fieldName>
+        </logLevel>
         <stackTrace>
           <throwableConverter class="net.logstash.logback.stacktrace.ShortenedThrowableConverter">
-            <maxDepthPerThrowable>30</maxDepthPerThrowable>
-            <shortenedClassNameLength>20</shortenedClassNameLength>
+            <maxDepthPerThrowable>20</maxDepthPerThrowable>
+            <maxLength>1000</maxLength>
+            <shortenedClassNameLength>30</shortenedClassNameLength>
+            <rootCauseFirst>true</rootCauseFirst>
             <exclude>^sun\.reflect\..*\.invoke</exclude>
             <exclude>^net\.sf\.cglib\.proxy\.MethodProxy\.invoke</exclude>
-            <rootCauseFirst>true</rootCauseFirst>
           </throwableConverter>
         </stackTrace>
+        <context/>
+        <jsonMessage/>
+        <mdc>
+          <includeMdcKeyName>included</includeMdcKeyName>
+        </mdc>
+        <contextMap/>
+        <tags/>
+        <logstashMarkers/>
+        <arguments>
+          <includeNonStructuredArguments>true</includeNonStructuredArguments>
+          <nonStructuredArgumentsFieldPrefix>prefix</nonStructuredArgumentsFieldPrefix>
+        </arguments>
       </providers>
     </encoder>
     <filter class="ch.qos.logback.classic.filter.ThresholdFilter">

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpointIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpointIT.java
@@ -9,6 +9,8 @@ import static org.junit.Assert.assertNotNull;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.Unirest;
 import java.io.ByteArrayInputStream;
@@ -16,7 +18,6 @@ import java.io.IOException;
 import java.util.UUID;
 import java.util.concurrent.BlockingQueue;
 import javax.xml.bind.JAXBContext;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -44,11 +45,11 @@ import uk.gov.ons.tools.rabbit.SimpleMessageBase;
 import uk.gov.ons.tools.rabbit.SimpleMessageListener;
 import uk.gov.ons.tools.rabbit.SimpleMessageSender;
 
-@Slf4j
 @ContextConfiguration
 @ActiveProfiles("test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class CaseEndpointIT {
+  private static final Logger log = LoggerFactory.getLogger(CaseEndpointIT.class);
 
   @ClassRule public static final SpringClassRule SPRING_CLASS_RULE = new SpringClassRule();
 


### PR DESCRIPTION
# Motivation and Context
We've agreed to use the Godaddy logger for structured JSON logging, which we are now rolling out to all the Java services.

# What has changed
Replaced all the `@Slf4j` annotations. Updated the logback.xml config.

# How to test?
Run with CLOUD profile and check that the logs are coming out in the correct JSON format.

# Links
Trello: https://trello.com/c/2cLIClJa/348-roll-out-godaddy-logger-to-all-the-other-java-services

Architecture decision: https://github.com/ONSdigital/sdc/blob/master/doc/architecture/decisions/godaddy-structured-json-logging-java.md