### PR TITLE
Init JSON logging in PostConstruct method

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@
         <dependency>
             <groupId>uk.gov.ons.ctp.common</groupId>
             <artifactId>framework</artifactId>
-            <version>10.49.16</version>
+            <version>10.49.17</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/CaseSvcApplication.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/CaseSvcApplication.java
@@ -1,13 +1,13 @@
 package uk.gov.ons.ctp.response.casesvc;
 
 import com.godaddy.logging.LoggingConfigs;
+import javax.annotation.PostConstruct;
 import net.sourceforge.cobertura.CoverageIgnore;
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
 import org.redisson.config.Config;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
@@ -50,7 +50,7 @@ import uk.gov.ons.ctp.response.casesvc.state.CaseSvcStateTransitionManagerFactor
 @EntityScan("uk.gov.ons.ctp.response")
 @EnableAsync
 @ImportResource("springintegration/main.xml")
-public class CaseSvcApplication implements CommandLineRunner {
+public class CaseSvcApplication {
 
   public static final String CASE_DISTRIBUTION_LIST = "casesvc.case.distribution";
   public static final String REPORT_EXECUTION_LOCK = "casesvc.report.execution";
@@ -76,8 +76,8 @@ public class CaseSvcApplication implements CommandLineRunner {
     SpringApplication.run(CaseSvcApplication.class, args);
   }
 
-  @Override
-  public void run(String... args) throws Exception {
+  @PostConstruct
+  public void initJsonLogging() {
     if (appConfig.getLogging().isUseJson()) {
       LoggingConfigs.setCurrent(LoggingConfigs.getCurrent().useJson());
     }


### PR DESCRIPTION
# Motivation and Context
Bug discovered by @ajmaddaford in CI-latest where JSON not being used for key-value pairs.

# What has changed
Instead of flipping logging to use JSON in a `CommandLineRunner.run()` method, we're using a `@Postconstruct` instead, which should always fire.

# How to test?
Run with `--spring.profiles.active=cloud` or hack the `application.yml` to set `CLOUD` logger and `useJson=true`

# Links
Related Trello card: https://trello.com/c/KNOUa0pq/349-update-logging-in-all-java-services-to-use-key-value-pairs