### PR TITLE
SUS006 - Allow all IACs to be disabled for a case

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/CaseIACService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/CaseIACService.java
@@ -2,6 +2,7 @@ package uk.gov.ons.ctp.response.casesvc.service;
 
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.common.service.CTPService;
+import uk.gov.ons.ctp.response.casesvc.domain.model.Case;
 import uk.gov.ons.ctp.response.casesvc.domain.model.CaseIacAudit;
 
 /**
@@ -15,4 +16,6 @@ public interface CaseIACService extends CTPService {
   String findCaseIacByCasePK(int caseFK);
 
   CaseIacAudit findCaseByIac(String iac) throws CTPException;
+
+  void disableAllIACsForCase(Case caze);
 }

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/InternetAccessCodeSvcClientService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/InternetAccessCodeSvcClientService.java
@@ -18,7 +18,7 @@ public interface InternetAccessCodeSvcClientService {
    *
    * @param iac the one to disable
    */
-  void disableIAC(String iac);
+  Boolean disableIAC(String iac);
 
   /**
    * To determine if a given iac is active

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/InternetAccessCodeSvcClientService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/InternetAccessCodeSvcClientService.java
@@ -18,7 +18,7 @@ public interface InternetAccessCodeSvcClientService {
    *
    * @param iac the one to disable
    */
-  Boolean disableIAC(String iac);
+  boolean disableIAC(String iac);
 
   /**
    * To determine if a given iac is active

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseIACServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseIACServiceImpl.java
@@ -4,7 +4,6 @@ import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
 import java.sql.Timestamp;
 import java.time.Clock;
-import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -96,7 +95,12 @@ public class CaseIACServiceImpl implements CaseIACService {
   }
 
   public void disableAllIACsForCase(Case caze) {
-    List<CaseIacAudit> caseIacAudits = caze.getIacAudits();
-    caseIacAudits.forEach(caseIacAudit -> iacClient.disableIAC(caseIacAudit.getIac()));
+    caze.getIacAudits()
+        .forEach(
+            caseIacAudit -> {
+              if (!iacClient.disableIAC(caseIacAudit.getIac())) {
+                log.with("caseId", caze.getId()).error("Failed to disable an IAC for case");
+              }
+            });
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseIACServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseIACServiceImpl.java
@@ -4,10 +4,13 @@ import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
 import java.sql.Timestamp;
 import java.time.Clock;
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.response.casesvc.domain.model.Case;
 import uk.gov.ons.ctp.response.casesvc.domain.model.CaseEvent;
 import uk.gov.ons.ctp.response.casesvc.domain.model.CaseIacAudit;
 import uk.gov.ons.ctp.response.casesvc.domain.repository.CaseEventRepository;
@@ -91,5 +94,10 @@ public class CaseIACServiceImpl implements CaseIACService {
             .iac(iac)
             .build();
     caseIacAuditRepo.save(audit);
+  }
+
+  public void disableAllIACsForCase(Case caze) {
+    List<CaseIacAudit> caseIacAudits = caze.getIacAudits();
+    caseIacAudits.forEach(caseIacAudit -> iacClient.disableIAC(caseIacAudit.getIac()));
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseIACServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseIACServiceImpl.java
@@ -5,7 +5,6 @@ import com.godaddy.logging.LoggerFactory;
 import java.sql.Timestamp;
 import java.time.Clock;
 import java.util.List;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImpl.java
@@ -609,7 +609,7 @@ public class CaseServiceImpl implements CaseService {
                   .getCategoryName()
                   .equals(CategoryDTO.CategoryName.SUCCESSFUL_RESPONSE_UPLOAD))
           || transitionEvent == CaseDTO.CaseEvent.ACCOUNT_CREATED) {
-          caseIacAuditService.disableAllIACsForCase(targetCase);
+        caseIacAuditService.disableAllIACsForCase(targetCase);
       }
 
       CaseState oldState = targetCase.getState();

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImpl.java
@@ -609,9 +609,7 @@ public class CaseServiceImpl implements CaseService {
                   .getCategoryName()
                   .equals(CategoryDTO.CategoryName.SUCCESSFUL_RESPONSE_UPLOAD))
           || transitionEvent == CaseDTO.CaseEvent.ACCOUNT_CREATED) {
-        if (targetCase.getIac() != null) {
-          internetAccessCodeSvcClientService.disableIAC(targetCase.getIac());
-        }
+          caseIacAuditService.disableAllIACsForCase(targetCase);
       }
 
       CaseState oldState = targetCase.getState();

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/InternetAccessCodeSvcClientServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/InternetAccessCodeSvcClientServiceImpl.java
@@ -71,7 +71,7 @@ public class InternetAccessCodeSvcClientServiceImpl implements InternetAccessCod
       maxAttemptsExpression = "#{${retries.maxAttempts}}",
       backoff = @Backoff(delayExpression = "#{${retries.backoff}}"))
   @Override
-  public Boolean disableIAC(String iac) {
+  public boolean disableIAC(String iac) {
     log.debug("Disabling iac code");
     UriComponents uriComponents =
         restUtility.createUriComponents(

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/InternetAccessCodeSvcClientServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/impl/InternetAccessCodeSvcClientServiceImpl.java
@@ -71,7 +71,7 @@ public class InternetAccessCodeSvcClientServiceImpl implements InternetAccessCod
       maxAttemptsExpression = "#{${retries.maxAttempts}}",
       backoff = @Backoff(delayExpression = "#{${retries.backoff}}"))
   @Override
-  public void disableIAC(String iac) {
+  public Boolean disableIAC(String iac) {
     log.debug("Disabling iac code");
     UriComponents uriComponents =
         restUtility.createUriComponents(
@@ -79,9 +79,17 @@ public class InternetAccessCodeSvcClientServiceImpl implements InternetAccessCod
     HttpEntity<UpdateInternetAccessCodeDTO> httpEntity =
         restUtility.createHttpEntity(new UpdateInternetAccessCodeDTO(SYSTEM));
 
-    restTemplate.exchange(
-        uriComponents.toUri(), HttpMethod.PUT, httpEntity, InternetAccessCodeDTO.class);
+    ResponseEntity responseEntity =
+        restTemplate.exchange(
+            uriComponents.toUri(), HttpMethod.PUT, httpEntity, InternetAccessCodeDTO.class);
+
+    if (!responseEntity.getStatusCode().is2xxSuccessful()) {
+      log.with("httpStatusCode", responseEntity.getStatusCodeValue())
+          .error("Failed to disable IAC");
+      return false;
+    }
     log.debug("Successfully disabled iac code");
+    return true;
   }
 
   @Retryable(

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseIACServiceTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseIACServiceTest.java
@@ -2,17 +2,23 @@ package uk.gov.ons.ctp.response.casesvc.service.impl;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.sql.Timestamp;
 import java.time.Clock;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.ons.ctp.response.casesvc.domain.model.Case;
 import uk.gov.ons.ctp.response.casesvc.domain.model.CaseEvent;
 import uk.gov.ons.ctp.response.casesvc.domain.model.CaseIacAudit;
 import uk.gov.ons.ctp.response.casesvc.domain.repository.CaseEventRepository;
@@ -24,6 +30,7 @@ import uk.gov.ons.ctp.response.casesvc.service.InternetAccessCodeSvcClientServic
 public class CaseIACServiceTest {
 
   @Mock private InternetAccessCodeSvcClientService iacClient;
+  @Mock private Case mockedCase;
   @Mock private CaseIacAuditRepository caseIacAuditRepository;
   @Mock private CaseEventRepository caseEventRepository;
   @Mock private Clock clock;
@@ -85,5 +92,60 @@ public class CaseIACServiceTest {
             .createdDateTime(Timestamp.from(now))
             .build();
     verify(caseIacAuditRepository).save(audit);
+  }
+
+  @Test
+  public void shouldDisableAllIACsForCaseWhenMultipleIACsExist() {
+    // Given
+    List<CaseIacAudit> listOf3IACAudits = new ArrayList<>();
+
+    listOf3IACAudits.add(createCaseIacAudit("IAC1"));
+    listOf3IACAudits.add(createCaseIacAudit("IAC2"));
+    listOf3IACAudits.add(createCaseIacAudit("IAC3"));
+
+    when(mockedCase.getIacAudits()).thenReturn(listOf3IACAudits);
+
+    // When
+    caseIACService.disableAllIACsForCase(mockedCase);
+
+    // Then
+    verify(iacClient).disableIAC("IAC1");
+    verify(iacClient).disableIAC("IAC2");
+    verify(iacClient).disableIAC("IAC3");
+  }
+
+  @Test
+  public void shouldDisableOneIACForCaseWhenOneIACExists() {
+    // Given
+    List<CaseIacAudit> listOfSingleIAC = new ArrayList<>();
+
+    listOfSingleIAC.add(createCaseIacAudit("IAC1"));
+
+    when(mockedCase.getIacAudits()).thenReturn(listOfSingleIAC);
+
+    // When
+    caseIACService.disableAllIACsForCase(mockedCase);
+
+    // Then
+    verify(iacClient).disableIAC("IAC1");
+  }
+
+  @Test
+  public void shouldNotTryToDisableIACForCaseWhenNoneExist() {
+    // Given
+    List<CaseIacAudit> emptyIACList = new ArrayList<>();
+
+    when(mockedCase.getIacAudits()).thenReturn(emptyIACList);
+
+    // When
+    caseIACService.disableAllIACsForCase(mockedCase);
+
+    // Then
+    verify(iacClient, times(0)).disableIAC(any(String.class));
+  }
+
+  /** mock iac audit * */
+  private CaseIacAudit createCaseIacAudit(String IAC) {
+    return new CaseIacAudit(1, 1, IAC, new Timestamp(System.currentTimeMillis()));
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/service/impl/CaseServiceImplTest.java
@@ -417,9 +417,11 @@ public class CaseServiceImplTest {
     Case caseSaved = argument.getValue();
     assertEquals(1, caseSaved.getResponses().size());
     assertEquals(CaseState.INACTIONABLE, caseSaved.getState());
+    when(caseSaved.getIacAudits())
+        .thenReturn(Collections.singletonList(createCaseIacAudit(IAC_FOR_TEST)));
 
     // IAC should be disabled for online responses
-    verify(internetAccessCodeSvcClientService, times(1)).disableIAC(any(String.class));
+    verify(internetAccessCodeSvcClientService, times(1)).disableIAC(IAC_FOR_TEST);
 
     // action service should be told of case state change
     verify(notificationPublisher, times(1)).sendNotification(any(CaseNotification.class));
@@ -1789,6 +1791,11 @@ public class CaseServiceImplTest {
     caseEvent.setDescription(CASEEVENT_DESCRIPTION);
     caseEvent.setSubCategory(CASEEVENT_SUBCATEGORY);
     return caseEvent;
+  }
+
+  /** mock iac audit * */
+  private CaseIacAudit createCaseIacAudit(String IAC) {
+    return new CaseIacAudit(1, 1, IAC, new Timestamp(System.currentTimeMillis()));
   }
 
   /** mock loading data */

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/service/impl/InternetAccessCodeSvcClientServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/service/impl/InternetAccessCodeSvcClientServiceImplTest.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.ctp.response.casesvc.service.impl;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -121,6 +122,9 @@ public class InternetAccessCodeSvcClientServiceImplTest {
     HttpEntity httpEntity = new HttpEntity<>(updateInternetAccessCodeDTO, null);
     when(restUtility.createHttpEntity(any(UpdateInternetAccessCodeDTO.class)))
         .thenReturn(httpEntity);
+    when(restTemplate.exchange(
+            uriComponents.toUri(), HttpMethod.PUT, httpEntity, InternetAccessCodeDTO.class))
+        .thenReturn(new ResponseEntity<>(HttpStatus.OK));
 
     iacSvcClientService.disableIAC(IAC);
 
@@ -132,6 +136,40 @@ public class InternetAccessCodeSvcClientServiceImplTest {
             eq(HttpMethod.PUT),
             eq(httpEntity),
             eq(InternetAccessCodeDTO.class));
+  }
+
+  @Test
+  public void testFailedToDisableIAC() {
+
+    // Given
+    InternetAccessCodeSvc iacSvcConfig = new InternetAccessCodeSvc();
+    iacSvcConfig.setIacPutPath(IAC_PUT_PATH);
+    when(appConfig.getInternetAccessCodeSvc()).thenReturn(iacSvcConfig);
+
+    UriComponents uriComponents =
+        UriComponentsBuilder.newInstance()
+            .scheme(HTTP)
+            .host(LOCALHOST)
+            .port(80)
+            .path(IAC_PUT_PATH)
+            .build();
+    when(restUtility.createUriComponents(any(String.class), eq(null), eq(IAC)))
+        .thenReturn(uriComponents);
+
+    UpdateInternetAccessCodeDTO updateInternetAccessCodeDTO =
+        new UpdateInternetAccessCodeDTO("SYSTEM");
+    HttpEntity httpEntity = new HttpEntity<>(updateInternetAccessCodeDTO, null);
+    when(restUtility.createHttpEntity(any(UpdateInternetAccessCodeDTO.class)))
+        .thenReturn(httpEntity);
+    when(restTemplate.exchange(
+            uriComponents.toUri(), HttpMethod.PUT, httpEntity, InternetAccessCodeDTO.class))
+        .thenReturn(new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR));
+
+    // When
+    Boolean isDisableIACSuccessful = iacSvcClientService.disableIAC(IAC);
+
+    // Then
+    assertFalse(isDisableIACSuccessful);
   }
 
   @Test


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It is now possible to have multiple IACs for one case. We need to be able to disable **all** of these IACs for a disabled case event.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
* Added a new method to disable all IACs for a case.
* Updated existing unit tests.
* Added unit tests.
* Remove two no longer valid unit tests

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
* Checkout this branch
* Run acceptance tests
* Check the acceptance test pass.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/4ukDtQX9/216-sus006-disable-uac-when-response-status-is-changed-to-data-to-be-deleted-5)