### PR TITLE
Allow offline response processed category to handle B cases

### DIFF
--- a/src/main/resources/database/changelog-master.yml
+++ b/src/main/resources/database/changelog-master.yml
@@ -79,3 +79,6 @@ databaseChangeLog:
 
   - include:
       file: database/changes/release-14/changelog.yml
+
+  - include:
+          file: database/changes/release-15/changelog.yml

--- a/src/main/resources/database/changes/release-15/changelog.yml
+++ b/src/main/resources/database/changes/release-15/changelog.yml
@@ -1,0 +1,10 @@
+databaseChangeLog:
+- changeSet:
+    id: 15-1
+    author: Gemma Irving
+    changes:
+    - sqlFile:
+        comment: Add B case to old case sample unit types for offline response processed category
+        path: update_offline_response_category_to_handle_b_cases.sql
+        relativeToChangelogFile: true
+        splitStatements: false

--- a/src/main/resources/database/changes/release-15/update_offline_response_category_to_handle_b_cases.sql
+++ b/src/main/resources/database/changes/release-15/update_offline_response_category_to_handle_b_cases.sql
@@ -1,0 +1,3 @@
+UPDATE casesvc.category
+SET oldcasesampleunittypes = 'B,BI,H'
+WHERE categorypk = 'OFFLINE_RESPONSE_PROCESSED';


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Since Frontstage only handles B cases the case id sent to EQ now has changed to a B case so this is the case id that is being receipted to SDX-Gateway. However the case event used to update case group status to completed for anything coming from SDX Gateway did not handle B cases. This changes allows that event category to handle B cases as well as BI cases.

# What has changed
<!--- What code changes has been made -->
A database change script has been added to update offline response processed event category to handle B cases.
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
[Trello] https://trello.com/c/f76uKk7R
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
