### PR TITLE
Add data migration to remove completed cases from action

### DIFF
--- a/migration/remove-completed-cases-from-action/1_get_case_ids_of_completed_actionable_cases_to_csv.sql
+++ b/migration/remove-completed-cases-from-action/1_get_case_ids_of_completed_actionable_cases_to_csv.sql
@@ -1,0 +1,1 @@
+\copy (SELECT id FROM casesvc.case WHERE statefk = 'ACTIONABLE' and casegroupfk in (SELECT casegrouppk FROM casesvc.casegroup WHERE status = 'COMPLETEDBYPHONE' or status = 'NOLONGERREQUIRED' or status = 'COMPLETE')) TO STDOUT WITH CSV

--- a/migration/remove-completed-cases-from-action/2_create_temporary_table_in_action.sql
+++ b/migration/remove-completed-cases-from-action/2_create_temporary_table_in_action.sql
@@ -1,0 +1,4 @@
+CREATE TABLE action.temp_cases
+(
+	case_id UUID
+)

--- a/migration/remove-completed-cases-from-action/3_save_case_ids_to_temp_table.sql
+++ b/migration/remove-completed-cases-from-action/3_save_case_ids_to_temp_table.sql
@@ -1,0 +1,1 @@
+COPY actionsvc.temp_cases(case_id) FROM STDIN WITH CSV;

--- a/migration/remove-completed-cases-from-action/4_delete_completed_cases_from_action.sql
+++ b/migration/remove-completed-cases-from-action/4_delete_completed_cases_from_action.sql
@@ -1,0 +1,2 @@
+delete from action.case
+WHERE id in (SELECT case_id FROM action.temp_cases)

--- a/migration/remove-completed-cases-from-action/README.md
+++ b/migration/remove-completed-cases-from-action/README.md
@@ -1,0 +1,24 @@
+## Delete completed cases from action service
+This folder contains scripts to delete all cases from the action service that have completed case group statuses.
+
+### Scripts
+Export the case ids of cases that have a completed case group status but are in state actionable to a csv file
+
+```
+psql "{CASE_POSTGRES_URI}" -f 1_get_case_ids_of_completed_actionable_cases_to_csv.sql > temp_cases.csv
+```
+
+Create temporary table for case ids in action service
+```
+psql "{ACTION_POSTGRES_URI}" -f 2_create_temporary_table_in_action.sql
+```
+
+Copy case ids from the csv to temporary table
+```
+psql "{ACTION_POSTGRES_URI}" -c "COPY actionsvc.temp_cases(case_id) FROM STDIN WITH CSV;" < temp_cases.csv
+```
+
+Delete completed cases from action service
+```
+psql "{ACTION_POSTGRES_URI}" -f 4_delete_completed_cases_from_action.sql
+```


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This data migration can be used to remove cases that are complete but have not been removed from the action service. This should stop people getting reminders they shouldn't when another respondent for that business has responded.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
