### PR TITLE
Bump rm-common-service version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@
         <dependency>
             <groupId>uk.gov.ons.ctp.common</groupId>
             <artifactId>framework</artifactId>
-          <version>10.49.18</version>
+          <version>10.49.19</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
# Motivation and Context
Fix for multithreading DateFormat bug worked, but introduced a regression bug when handling obscure dates.

# What has changed
Bumped the dependency version of `rm-common-service` to use the new version with the bug fixed.

# How to test?
All acceptance tests, regression & concurrency testing.

# Links
Trello: https://trello.com/c/bGt4TX2Q/405-bug-bad-dates-being-returned-by-java-services-under-load#