### PR TITLE
Update snapshot version to 10.49.22

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>casesvc</artifactId>
-    <version>10.49.20-SNAPSHOT</version>
+    <version>10.49.22-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>CTP : CaseService</name>


### PR DESCRIPTION
We recently had to do a bug fix off an earlier release and create a jar from it in artifactory. Because of that we are out of step and the snapshot version needs updating