### PR TITLE
Fixing docker compose file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -266,6 +266,7 @@
                         </goals>
                         <configuration>
                             <composeFile>${project.basedir}/docker-compose.yml</composeFile>
+                            <skip>${dockerComposeSkip}</skip>
                         </configuration>
                     </execution>
                     <execution>
@@ -277,6 +278,7 @@
                         <configuration>
                             <composeFile>${project.basedir}/docker-compose.yml</composeFile>
                             <detachedMode>true</detachedMode>
+                            <skip>${dockerComposeSkip}</skip>
                         </configuration>
                     </execution>
                     <execution>
@@ -287,6 +289,7 @@
                         </goals>
                         <configuration>
                             <composeFile>${project.basedir}/docker-compose.yml</composeFile>
+                            <skip>${dockerComposeSkip}</skip>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
# Motivation and Context
On concourse, it skips creating the dockerfile and integration tests. When a change went in replacing one of the docker plugins, the command on RAS-deploy wasn't updated and it couldn't skip over it. This change allows the casesvc to skip the creation of the docker containers by adding an environment variable to skip the tests. A PR will be made in RAS-deploy to add the variable to the pipeline when running its tests

# What has changed
- Added skip to docker-compose-maven-plugin

# How to test?
run `mvn clean install -DdockerComposeSkip -Ddockerfile.skip  -DskipITs -Dhttp.wait.skip`and the integration tests should be skipped as well as the creation of the docker containers
