### PR TITLE
Fix migration script and instructions

### DIFF
--- a/migration/get-surveyid-to-collection-exercises/1_get-collection-exercises.sql
+++ b/migration/get-surveyid-to-collection-exercises/1_get-collection-exercises.sql
@@ -1,1 +1,1 @@
-\copy(select id, survey_uuid from collectionexercise.collectionexercise where statefk = "LIVE" or statefk ="READY_FOR_LIVE") TO STDOUT WITH CSV;
+copy(select id, survey_uuid from collectionexercise.collectionexercise where statefk = 'LIVE' or statefk = 'READY_FOR_LIVE') TO STDOUT WITH CSV;

--- a/migration/get-surveyid-to-collection-exercises/3_import-temp-table.sql
+++ b/migration/get-surveyid-to-collection-exercises/3_import-temp-table.sql
@@ -1,1 +1,1 @@
-COPY case_temp(collectionexerciseid, surveyid) FROM 'temp_collex.csv' DELIMITER ',' CSV HEADER;
+\COPY casesvc.case_temp(collectionexerciseid, surveyid) FROM 'temp_collex.csv' DELIMITER ',' CSV HEADER;

--- a/migration/get-surveyid-to-collection-exercises/3_import-temp-table.sql
+++ b/migration/get-surveyid-to-collection-exercises/3_import-temp-table.sql
@@ -1,1 +1,1 @@
-COPY casesvc.case_temp(collectionexerciseid, surveyid) FROM STDIN WITH CSV;
+COPY case_temp(collectionexerciseid, surveyid) FROM 'temp_collex.csv' DELIMITER ',' CSV HEADER;

--- a/migration/get-surveyid-to-collection-exercises/README.md
+++ b/migration/get-surveyid-to-collection-exercises/README.md
@@ -6,20 +6,20 @@ The scripts in this folder are used to add the surveyid to the case groups table
 
 Getting all executed collection exercises with survey ids
 
-``psql "{COLLEX_POSTGRES_URI}" -f 1_get-collection-exercises.sql > temp_collex.csv``
+`psql "{COLLEX_POSTGRES_URI}" -f 1_get-collection-exercises.sql > temp_collex.csv`
 
 Creating temporary table
 
-``psql "{CASE_POSTGRES_URI}" -f 2_create_temp_table.sql ``
+`psql "{CASE_POSTGRES_URI}" -f 2_create-temp-table.sql`
 
 importing temporary table
 
-``psql "{CASE_POSTGRES_URI}" -c "COPY casesvc.case_temp(collectionexerciseid, survey_uuid) FROM STDIN WITH CSV;"< temp_collex.csv``
+`psql "{CASE_POSTGRES_URI}" -f 3_import-temp-table.sql < temp_collex.csv`
 
 Adding survey id to the case groups table
 
-``psql "{CASE_POSTGRES_URI}" -f 4_add-surveyid-to-case-groups.sql``
+`psql "{CASE_POSTGRES_URI}" -f 4_add-surveyid-to-case-groups.sql`
 
 Dropping temporary table
 
-``psql ""{CASE_POSTGRES_URI}" -f 5_drop-temp-table.sql``
+`psql "{CASE_POSTGRES_URI}" -f 5_drop-temp-table.sql`

--- a/migration/get-surveyid-to-collection-exercises/README.md
+++ b/migration/get-surveyid-to-collection-exercises/README.md
@@ -14,7 +14,7 @@ Creating temporary table
 
 importing temporary table
 
-`psql "{CASE_POSTGRES_URI}" -f 3_import-temp-table.sql < temp_collex.csv`
+`psql "{CASE_POSTGRES_URI}" -f 3_import-temp-table.sql`
 
 Adding survey id to the case groups table
 


### PR DESCRIPTION
# Motivation and Context
When testing in latest, there were a few problems with the migration scripts and instructions for copying the survey IDs out of collex and into case.

# What has changed
Updated the scripts and instructions in `migrations/get-surveyid-to-collection-exercises`

# How to test?
Follow the steps in `migration/get-surveyid-to-collection-exercises/README.md`

# Links
Trello: https://trello.com/c/Av0xoJzP/516-fix-case-survey-id-migration-scripts-instructions
Related PR: https://trello.com/c/WNaIX2HO/295-add-survey-id-to-casegroups-l