### PR TITLE
Fix for intermittent test failure

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:8145/info"]
       interval: 30s
       timeout: 10s
-      retries: 5
+      retries: 10
 
   survey:
     container_name: survey-case-it
@@ -91,7 +91,7 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:8151/info"]
       interval: 30s
       timeout: 10s
-      retries: 5
+      retries: 10
 
   start_dependencies:
     image: dadarek/wait-for-dependencies

--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock</artifactId>
-            <version>2.18.0</version>
+            <version>2.19.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -25,6 +25,10 @@ rabbitmq:
 data-grid:
   address: localhost:17379
 
+case-distribution:
+  retrieval-max: 50
+  delay-milli-seconds: 5000
+
 schedules:
   validation-schedule-delay-milli-seconds: 1000
   distribution-schedule-delay-milli-seconds: 1000

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -27,7 +27,7 @@ data-grid:
 
 case-distribution:
   retrieval-max: 50
-  delay-milli-seconds: 5000
+  delay-milli-seconds: 500
 
 schedules:
   validation-schedule-delay-milli-seconds: 1000

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpointIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpointIT.java
@@ -24,6 +24,8 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import uk.gov.ons.ctp.common.UnirestInitialiser;
 import uk.gov.ons.ctp.response.casesvc.CaseCreator;
 import uk.gov.ons.ctp.response.casesvc.client.CollectionExerciseSvcClient;
+import uk.gov.ons.ctp.response.casesvc.domain.repository.CaseEventRepository;
+import uk.gov.ons.ctp.response.casesvc.domain.repository.CaseRepository;
 import uk.gov.ons.ctp.response.casesvc.message.notification.CaseNotification;
 import uk.gov.ons.ctp.response.casesvc.representation.CaseDetailsDTO;
 import uk.gov.ons.ctp.response.casesvc.representation.CaseEventCreationRequestDTO;
@@ -49,6 +51,8 @@ public class CaseEndpointIT {
 
   @Autowired private CaseCreator caseCreator;
   @Autowired private CollectionExerciseSvcClient collectionExerciseSvcClient;
+  @Autowired private CaseRepository caseRepository;
+  @Autowired private CaseEventRepository caseEventRepository;
 
   @BeforeClass
   public static void setUp() {
@@ -58,6 +62,9 @@ public class CaseEndpointIT {
 
   @Before
   public void testSetup() {
+    caseEventRepository.deleteAll();
+    caseRepository.deleteAll();
+
     Random rnd = new Random();
 
     int randNumber = 10000 + rnd.nextInt(900000);

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpointIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpointIT.java
@@ -15,6 +15,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.embedded.LocalServerPort;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -36,6 +37,7 @@ import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExer
 @ActiveProfiles("test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @RunWith(SpringJUnit4ClassRunner.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class CaseEndpointIT {
 
   private UUID collectionExerciseId;

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpointIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpointIT.java
@@ -10,10 +10,7 @@ import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.Unirest;
 import java.util.Random;
 import java.util.UUID;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.embedded.LocalServerPort;
@@ -43,8 +40,8 @@ public class CaseEndpointIT {
 
   private UUID collectionExerciseId;
 
-  @Rule
-  public WireMockRule wireMockRule =
+  @ClassRule
+  public static WireMockRule wireMockRule =
       new WireMockRule(options().extensions(new ResponseTemplateTransformer(false)).port(18002));
 
   @LocalServerPort private int port;
@@ -55,9 +52,10 @@ public class CaseEndpointIT {
   @Autowired private CaseEventRepository caseEventRepository;
 
   @BeforeClass
-  public static void setUp() {
+  public static void setUp() throws InterruptedException {
     ObjectMapper value = new ObjectMapper();
     UnirestInitialiser.initialise(value);
+    Thread.sleep(2000);
   }
 
   @Before

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseIACEndpointIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseIACEndpointIT.java
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.embedded.LocalServerPort;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -39,6 +40,7 @@ import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExer
 @ActiveProfiles("test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @RunWith(SpringJUnit4ClassRunner.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class CaseIACEndpointIT {
   private UUID collectionExerciseId;
 

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseIACEndpointIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseIACEndpointIT.java
@@ -18,10 +18,7 @@ import com.mashape.unirest.http.Unirest;
 import com.mashape.unirest.http.exceptions.UnirestException;
 import java.util.Random;
 import java.util.UUID;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.embedded.LocalServerPort;
@@ -47,8 +44,8 @@ public class CaseIACEndpointIT {
 
   private static final Logger log = LoggerFactory.getLogger(CaseIACEndpointIT.class);
 
-  @Rule
-  public WireMockRule wireMockRule =
+  @ClassRule
+  public static WireMockRule wireMockRule =
       new WireMockRule(options().extensions(new ResponseTemplateTransformer(false)).port(18002));
 
   @LocalServerPort private int port;
@@ -57,9 +54,10 @@ public class CaseIACEndpointIT {
   @Autowired private CollectionExerciseSvcClient collectionExerciseSvcClient;
 
   @BeforeClass
-  public static void setUp() {
+  public static void setUp() throws InterruptedException {
     ObjectMapper value = new ObjectMapper();
     UnirestInitialiser.initialise(value);
+    Thread.sleep(2000);
   }
 
   @Before

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/message/CaseReceiptReceiverIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/message/CaseReceiptReceiverIT.java
@@ -20,6 +20,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.GenericMessage;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -41,6 +42,7 @@ import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExer
 @ActiveProfiles("test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @RunWith(SpringJUnit4ClassRunner.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class CaseReceiptReceiverIT {
 
   private UUID collectionExerciseId;

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/message/CaseReceiptReceiverIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/message/CaseReceiptReceiverIT.java
@@ -12,10 +12,7 @@ import com.sun.org.apache.xerces.internal.jaxp.datatype.XMLGregorianCalendarImpl
 import java.util.GregorianCalendar;
 import java.util.Random;
 import java.util.UUID;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.embedded.LocalServerPort;
@@ -48,8 +45,8 @@ public class CaseReceiptReceiverIT {
 
   private UUID collectionExerciseId;
 
-  @Rule
-  public WireMockRule wireMockRule =
+  @ClassRule
+  public static WireMockRule wireMockRule =
       new WireMockRule(options().extensions(new ResponseTemplateTransformer(false)).port(18002));
 
   @Autowired private MessageChannel caseReceiptTransformed;
@@ -61,9 +58,10 @@ public class CaseReceiptReceiverIT {
   @Autowired private CollectionExerciseSvcClient collectionExerciseSvcClient;
 
   @BeforeClass
-  public static void setUp() {
+  public static void setUp() throws InterruptedException {
     ObjectMapper value = new ObjectMapper();
     UnirestInitialiser.initialise(value);
+    Thread.sleep(2000);
   }
 
   @Before

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/message/RabbitSpringIntegrationDLQAndRetriesIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/message/RabbitSpringIntegrationDLQAndRetriesIT.java
@@ -18,6 +18,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.embedded.LocalServerPort;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.io.ResourceLoader;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -37,6 +38,7 @@ import uk.gov.ons.tools.rabbit.SimpleMessageSender;
 @ActiveProfiles("test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @RunWith(SpringJUnit4ClassRunner.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class RabbitSpringIntegrationDLQAndRetriesIT {
 
   @LocalServerPort private int port;

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/message/RabbitSpringIntegrationDLQAndRetriesIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/message/RabbitSpringIntegrationDLQAndRetriesIT.java
@@ -1,13 +1,17 @@
 package uk.gov.ons.ctp.response.casesvc.message;
 
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static org.junit.Assert.assertEquals;
 
+import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import java.io.ByteArrayInputStream;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import javax.xml.bind.JAXBContext;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,6 +40,10 @@ import uk.gov.ons.tools.rabbit.SimpleMessageSender;
 public class RabbitSpringIntegrationDLQAndRetriesIT {
 
   @LocalServerPort private int port;
+
+  @ClassRule
+  public static WireMockRule wireMockRule =
+      new WireMockRule(options().extensions(new ResponseTemplateTransformer(false)).port(18002));
 
   @Autowired AppConfig appConfig;
 


### PR DESCRIPTION
# Motivation and Context
Theres an intermittent bug in the case service tests where it gets stuck attempting to contact the IAC service wiremock. This only happened occasionally so its hard to test.

# What has changed
- Added classrule to the wiremock
- Added a thread sleep to allow the wiremock to shutdown and wake up between tests.

# How to test?
- running `mvn clean install` and it passing. When testing this I had to run it constantly just in case it happened again, so you may need to keep running the tests just to be thorough. Only merge when confident you can't replicate the bug.
