### PR TITLE
Add Artifactory repo to fix Concourse CI failure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,10 @@
 
             <repositories>
                 <repository>
+                    <id>jcenter-repo</id>
+                    <url>http://artifactory-sdc.onsdigital.uk/artifactory/jcenter-cache/</url>
+                </repository>
+                <repository>
                     <id>release-repo</id>
                     <name>libs-release</name>
                     <url>http://artifactory-sdc.onsdigital.uk/artifactory/libs-release-local</url>


### PR DESCRIPTION
# Motivation and Context
The Concourse CI pipeline is failing because the Action and Case services cannot download Zipkin dependencies. The dependencies are in Artifactory, but in a repo which we have not explicitly declared in our `pom.xml`.

# What has changed
Added `jcenter-cache` to list of Artifactory repos in the `pom.xml`.

# How to test?
Run the `case-service-ci-deploy-ci` job in Concourse.

# Links
Trello: https://trello.com/c/PtK76WEN/564-fix-action-case-ci-deploy-jobs-in-concourse