### PR TITLE
Updating receipt receiver to use user Id

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>casesvc</artifactId>
-    <version>10.49.26-SNAPSHOT</version>
+    <version>10.49.26</version>
     <packaging>jar</packaging>
 
     <name>CTP : CaseService</name>
@@ -18,7 +18,7 @@
         <connection>scm:git:https://github.com/ONSdigital/rm-case-service</connection>
         <developerConnection>scm:git:https://github.com/ONSdigital/rm-case-service</developerConnection>
         <url>https://github.com/ONSdigital/rm-case-service</url>
-        <tag>HEAD</tag>
+        <tag>casesvc-10.49.26</tag>
     </scm>
 
     <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <connection>scm:git:https://github.com/ONSdigital/rm-case-service</connection>
         <developerConnection>scm:git:https://github.com/ONSdigital/rm-case-service</developerConnection>
         <url>https://github.com/ONSdigital/rm-case-service</url>
-        <tag>casesvc-10.49.26</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <parent>

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/message/CaseReceiptReceiver.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/message/CaseReceiptReceiver.java
@@ -72,7 +72,7 @@ public class CaseReceiptReceiver {
     } else {
       CaseEvent caseEvent = new CaseEvent();
       String partyId = caseReceipt.getPartyId();
-      if (partyId != null) {
+      if (partyId != null && !partyId.isEmpty()) {
         Map<String, String> metadata = new HashMap<>();
         metadata.put("partyId", partyId);
         caseEvent.setMetadata(metadata);

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/message/CaseReceiptReceiver.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/message/CaseReceiptReceiver.java
@@ -71,10 +71,10 @@ public class CaseReceiptReceiver {
       log.with("case_id", caseId).error(EXISTING_CASE_NOT_FOUND);
     } else {
       CaseEvent caseEvent = new CaseEvent();
-      UUID partyId = existingCase.getPartyId();
+      String partyId = caseReceipt.getPartyId();
       if (partyId != null) {
         Map<String, String> metadata = new HashMap<>();
-        metadata.put("partyId", partyId.toString());
+        metadata.put("partyId", partyId);
         caseEvent.setMetadata(metadata);
       }
       caseEvent.setCaseFK(existingCase.getCasePK());


### PR DESCRIPTION
# Motivation and Context
To allow the userid to get passed from rm-sdx gateway to case service, we need to update the case receipt receiver to use the case receipt party id instead of the existing case party id.
# What has changed
- Changed partyid from the existing case to the case receipt

# How to test?
Need to run with [RM-SDX Gateway PR](https://github.com/ONSdigital/rm-sdx-gateway/pull/21)

To test this locally I send a POST request to RM-SDX Gateway at the http://localhost:8191/receipts which includes the caseid and partyid of the respondent which you can get if you debug frontstage when you click access survey for an eQ. You need to first make sure an eQ has been set to in progress before you can do this. This can be done by clicking access survey. If you look in the case events table then the partyId should be a respondent and looking at the response status for that eQ should show the respondent.
# Links
[trello](https://trello.com/c/Hd4vgVp5)
