### PR TITLE
Automate census docker build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,6 @@ jdk: openjdk8
 before_install:
 - cp .maven.settings.xml $HOME/.m2/settings.xml
 - mvn fmt:check
-- mvn package -DskipTests
-- if ([ "$TRAVIS_BRANCH" == "rm-census" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]) || ([ "$TRAVIS_BRANCH" == "automate-census-docker-build" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]); then
-  docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
-  docker tag casesvc "${DOCKER_GCP_LOCATION}"/casesvc;
-  docker push "${DOCKER_GCP_LOCATION}"/casesvc;
-  fi
 
 script: travis_wait mvn verify cobertura:cobertura-integration-test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,6 @@ after_success:
   fi
 - bash <(curl -s https://codecov.io/bash)
 
-notifications:
-  slack:
-    rooms:
-      secure: "NcFdQQ5QbZu6naz8goI75PLKkKrlgkEV6td9yYZ4Wt13ZgYdT+rE5NtQiLQbPqvX56/Lphmm8sYm2VV/I92ibK5/Xbr0RGDQ3nl6kcmdwmHDSsPPVWYQvAtuzcvsxI0CGVQ+ek/pZYFBNOnsqHi4Dxfe1jdcVZROUSVao8xE0Hey63wDNj5UNA8S6qOBEyJSMOZ5tR6R5Xr83LteVGGuvNlPnOFu5ehZKZLPChWlyOcnHcdHZbHCiclDJn/fYV40EQ2NcU2uoN+HxLPKHUBAK/DYUkSOzVkHJdDN3rn9SVWvu/Z9rDHF+0jPVPEmNexV4QfE1oR5OVhj/CdPo5K1D1sVSfbVZlsIj93ThrARdm3meA5MNJdBcPF1o6ira8tf1xw8CcVXuj4hV6ywcin0pHvMMMIWQx7HqVo1WCX1lRyf2HnP+Qvu69kGJVPQ0HCosYlMI9P5woqerdtayuX0UlYiGr8/0a1vKnN78zxM6LnabmK9KPW/xGVcY5H43vJwYjvkdSib8EA5+EwDj3u0HR9LRtv0Wi7Yoa1sKT/ZL8dXobIWGJef/vX4M9PaTqx5dA+kyr8L5JcCEBTfMvOaW6Q5UDkec28NIMh4F4CAQt2avgoBW/fZqLmSleNNtRnhXaGhODgzOnRSyILxCMfrcxWpFCbWzWwIPOFx2IR3f0k="
-    on_failure: never
-    on_success: never
-
 cache:
   directories:
   - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,10 @@ before_install:
 script: travis_wait mvn verify cobertura:cobertura-integration-test
 
 after_success:
+- echo $TRAVIS_BRANCH
+- echo $TRAVIS_PULL_REQUEST
 - if ([ "$TRAVIS_BRANCH" == "rm-census" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]) || ([ "$TRAVIS_BRANCH" == "automate-census-docker-build" ]); then
+  echo "RUNNING IN HERE"
   docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
   docker tag casesvc "${DOCKER_GCP_LOCATION}"/casesvc;
   docker push "${DOCKER_GCP_LOCATION}"/casesvc;

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,3 +34,4 @@ cache:
 branches:
   only:
   - rm-census
+  - automate-census-docker-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
 script: travis_wait mvn verify cobertura:cobertura-integration-test
 
 after_success:
-- if ([ "$TRAVIS_BRANCH" == "rm-census" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]) || ([ "$TRAVIS_BRANCH" == "automate-census-docker-build" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]); then
+- if ([ "$TRAVIS_BRANCH" == "rm-census" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]) || ([ "$TRAVIS_BRANCH" == "automate-census-docker-build" ]); then
   docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
   docker tag casesvc "${DOCKER_GCP_LOCATION}"/casesvc;
   docker push "${DOCKER_GCP_LOCATION}"/casesvc;

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,12 @@ jdk: openjdk8
 before_install:
 - cp .maven.settings.xml $HOME/.m2/settings.xml
 - mvn fmt:check
+- mvn package -DskipTests
+- if ([ "$TRAVIS_BRANCH" == "rm-census" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]) || ([ "$TRAVIS_BRANCH" == "automate-census-docker-build" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]); then
+  docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
+  docker tag casesvc "${DOCKER_GCP_LOCATION}"/casesvc;
+  docker push "${DOCKER_GCP_LOCATION}"/casesvc;
+  fi
 
 script: travis_wait mvn verify cobertura:cobertura-integration-test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
 script: travis_wait mvn verify cobertura:cobertura-integration-test
 
 after_success:
-- if [ "$TRAVIS_BRANCH" == "rm-census" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+- if ([ "$TRAVIS_BRANCH" == "rm-census" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]) || ([ "$TRAVIS_BRANCH" == "automate-census-docker-build" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]); then
   docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
   docker tag casesvc "${DOCKER_GCP_LOCATION}"/casesvc;
   docker push "${DOCKER_GCP_LOCATION}"/casesvc;

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,10 @@ before_install:
 script: travis_wait mvn verify cobertura:cobertura-integration-test
 
 after_success:
-- if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-  docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD";
-  docker push sdcplatform/casesvc;
+- if [ "$TRAVIS_BRANCH" == "rm-census" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+  docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
+  docker tag casesvc "${DOCKER_GCP_LOCATION}"/casesvc;
+  docker push "${DOCKER_GCP_LOCATION}"/casesvc;
   fi
 - bash <(curl -s https://codecov.io/bash)
 
@@ -23,7 +24,7 @@ notifications:
   slack:
     rooms:
       secure: "NcFdQQ5QbZu6naz8goI75PLKkKrlgkEV6td9yYZ4Wt13ZgYdT+rE5NtQiLQbPqvX56/Lphmm8sYm2VV/I92ibK5/Xbr0RGDQ3nl6kcmdwmHDSsPPVWYQvAtuzcvsxI0CGVQ+ek/pZYFBNOnsqHi4Dxfe1jdcVZROUSVao8xE0Hey63wDNj5UNA8S6qOBEyJSMOZ5tR6R5Xr83LteVGGuvNlPnOFu5ehZKZLPChWlyOcnHcdHZbHCiclDJn/fYV40EQ2NcU2uoN+HxLPKHUBAK/DYUkSOzVkHJdDN3rn9SVWvu/Z9rDHF+0jPVPEmNexV4QfE1oR5OVhj/CdPo5K1D1sVSfbVZlsIj93ThrARdm3meA5MNJdBcPF1o6ira8tf1xw8CcVXuj4hV6ywcin0pHvMMMIWQx7HqVo1WCX1lRyf2HnP+Qvu69kGJVPQ0HCosYlMI9P5woqerdtayuX0UlYiGr8/0a1vKnN78zxM6LnabmK9KPW/xGVcY5H43vJwYjvkdSib8EA5+EwDj3u0HR9LRtv0Wi7Yoa1sKT/ZL8dXobIWGJef/vX4M9PaTqx5dA+kyr8L5JcCEBTfMvOaW6Q5UDkec28NIMh4F4CAQt2avgoBW/fZqLmSleNNtRnhXaGhODgzOnRSyILxCMfrcxWpFCbWzWwIPOFx2IR3f0k="
-    on_failure: always
+    on_failure: never
     on_success: never
 
 cache:
@@ -32,4 +33,4 @@ cache:
 
 branches:
   only:
-  - master
+  - rm-census

--- a/pom.xml
+++ b/pom.xml
@@ -349,7 +349,7 @@
                         </goals>
                         <phase>package</phase>
                         <configuration>
-                            <repository>sdcplatform/${project.artifactId}</repository>
+                            <repository>${project.artifactId}</repository>
                             <buildArgs>
                                 <JAR_FILE>${project.build.finalName}.jar</JAR_FILE>
                             </buildArgs>


### PR DESCRIPTION
# Motivation and Context
We want travis build to push docker images to Google Container Registry instead of dockerhub

# What has changed
Replaced docker image prefix with GCR registry location
NOTE: before merge, remove "automate-census-docker-build" branch condition and "branches only" section in .travis.yml file

<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
From travis dashboard, switch to  "automate-census-docker-build" branch and "Restart Build". Once complete, check latest Docker image is in GCR.
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/dC6sEWqE/443-set-up-automated-docker-image-build)