### PR TITLE
Performance improvements

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpoint.java
@@ -139,7 +139,7 @@ public final class CaseEndpoint implements CTPEndpoint {
   public ResponseEntity<List<CaseDetailsDTO>> findCasesByPartyId(
       @PathVariable("partyId") final UUID partyId,
       @RequestParam(value = "caseevents", required = false) final boolean caseevents,
-      @RequestParam(value = "iac", required = false, defaultValue = "true") final boolean iac) {
+      @RequestParam(value = "iac", required = false) final boolean iac) {
     log.with("party_id", partyId).debug("Retrieving cases by party");
     List<Case> casesList = caseService.findCasesByPartyId(partyId, iac);
 

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpoint.java
@@ -139,9 +139,9 @@ public final class CaseEndpoint implements CTPEndpoint {
   public ResponseEntity<List<CaseDetailsDTO>> findCasesByPartyId(
       @PathVariable("partyId") final UUID partyId,
       @RequestParam(value = "caseevents", required = false) final boolean caseevents,
-      @RequestParam(value = "iac", required = false) final boolean iac) {
+      @RequestParam(value = "iac", required = false, defaultValue = "true") final boolean iac) {
     log.with("party_id", partyId).debug("Retrieving cases by party");
-    List<Case> casesList = caseService.findCasesByPartyId(partyId);
+    List<Case> casesList = caseService.findCasesByPartyId(partyId, iac);
 
     if (CollectionUtils.isEmpty(casesList)) {
       return ResponseEntity.noContent().build();

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/CaseService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/CaseService.java
@@ -156,10 +156,13 @@ public class CaseService {
    * @param partyId the partyId
    * @return the cases for the partyId
    */
-  public List<Case> findCasesByPartyId(final UUID partyId) {
+  public List<Case> findCasesByPartyId(final UUID partyId, boolean iac) {
     log.debug("Entering findCasesByPartyId");
     List<Case> cazes = caseRepo.findByPartyId(partyId);
-    cazes.stream().forEach(c -> c.setIac(caseIacAuditService.findCaseIacByCasePK(c.getCasePK())));
+
+    if (iac) {
+      cazes.stream().forEach(c -> c.setIac(caseIacAuditService.findCaseIacByCasePK(c.getCasePK())));
+    }
 
     return cazes;
   }

--- a/src/main/resources/database/changelog-master.yml
+++ b/src/main/resources/database/changelog-master.yml
@@ -94,3 +94,6 @@ databaseChangeLog:
 
   - include:
       file: database/changes/release-19/changelog.yml
+
+  - include:
+      file: database/changes/release-20/changelog.yml

--- a/src/main/resources/database/changes/release-19/changelog.yml
+++ b/src/main/resources/database/changes/release-19/changelog.yml
@@ -6,6 +6,6 @@ databaseChangeLog:
     changes:
     - sqlFile:
         comment: Adding metadata to case events table
-        path: add-index-to-partyid-on-case.sql
+        path:  add-metadata-to-caseevents.sql
         relativeToChangelogFile: true
         splitStatements: false

--- a/src/main/resources/database/changes/release-19/changelog.yml
+++ b/src/main/resources/database/changes/release-19/changelog.yml
@@ -6,6 +6,6 @@ databaseChangeLog:
     changes:
     - sqlFile:
         comment: Adding metadata to case events table
-        path:  add-metadata-to-caseevents.sql
+        path: add-metadata-to-caseevents.sql
         relativeToChangelogFile: true
         splitStatements: false

--- a/src/main/resources/database/changes/release-20/add-index-to-partyid-on-case.sql
+++ b/src/main/resources/database/changes/release-20/add-index-to-partyid-on-case.sql
@@ -1,0 +1,1 @@
+CREATE INDEX case_partyid_index ON casesvc."case" USING btree (partyid);

--- a/src/main/resources/database/changes/release-20/changelog.yml
+++ b/src/main/resources/database/changes/release-20/changelog.yml
@@ -1,11 +1,11 @@
 databaseChangeLog:
 
 - changeSet:
-    id: 19-1
-    author: Ryan Grundy
+    id: 20-1
+    author: Nick Grant
     changes:
     - sqlFile:
-        comment: Adding metadata to case events table
+        comment: Add index on partyid in case table
         path: add-index-to-partyid-on-case.sql
         relativeToChangelogFile: true
         splitStatements: false

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpointUnitTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpointUnitTest.java
@@ -360,7 +360,7 @@ public final class CaseEndpointUnitTest {
 
   @Test
   public void findCasesByPartyIdFoundWithoutCaseEventsAndIac() throws Exception {
-    when(caseService.findCasesByPartyId(EXISTING_PARTY_UUID)).thenReturn(caseResults);
+    when(caseService.findCasesByPartyId(EXISTING_PARTY_UUID, true)).thenReturn(caseResults);
     when(caseGroupService.findCaseGroupByCaseGroupPK(any(Integer.class)))
         .thenReturn(caseGroupResults.get(0));
     when(caseService.findCaseEventsByCaseFK(any(Integer.class))).thenReturn(caseEventsResults);
@@ -431,7 +431,7 @@ public final class CaseEndpointUnitTest {
 
   @Test
   public void findCasesByPartyIdFoundWithCaseEventsAndIac() throws Exception {
-    when(caseService.findCasesByPartyId(EXISTING_PARTY_UUID)).thenReturn(caseResults);
+    when(caseService.findCasesByPartyId(EXISTING_PARTY_UUID, true)).thenReturn(caseResults);
     when(caseGroupService.findCaseGroupByCaseGroupPK(any(Integer.class)))
         .thenReturn(caseGroupResults.get(0));
     when(caseService.findCaseEventsByCaseFK(any(Integer.class))).thenReturn(caseEventsResults);

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpointUnitTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpointUnitTest.java
@@ -360,7 +360,7 @@ public final class CaseEndpointUnitTest {
 
   @Test
   public void findCasesByPartyIdFoundWithoutCaseEventsAndIac() throws Exception {
-    when(caseService.findCasesByPartyId(EXISTING_PARTY_UUID, true)).thenReturn(caseResults);
+    when(caseService.findCasesByPartyId(EXISTING_PARTY_UUID, false)).thenReturn(caseResults);
     when(caseGroupService.findCaseGroupByCaseGroupPK(any(Integer.class)))
         .thenReturn(caseGroupResults.get(0));
     when(caseService.findCaseEventsByCaseFK(any(Integer.class))).thenReturn(caseEventsResults);


### PR DESCRIPTION
# Motivation and Context
In an attempt to make the to-do page on frontstage even quicker, We've decided that adding an index  on the case table for the partyid would help increase the speed. It will also now pass in a IAC boolean so it can skip adding the iac which removes another DB calls
# What has changed
- Added an index on the case table for the partyId column
- Added boolean check on IAC so it can be skipped

# How to test?
- Run with [frontstage PR](https://github.com/ONSdigital/ras-frontstage/pull/429)
- Run the acceptance tests
- Open up the todo page and make sure everything is working such as accessing survey and completing it.

# Links
[Trello](https://trello.com/c/5xsPP92s)

