### PR TITLE
Increase the default memory on startup to 2G

### DIFF
--- a/manifest-template.yml
+++ b/manifest-template.yml
@@ -3,7 +3,7 @@ applications:
   instances: INSTANCES
   timeout: 180
   host: casesvc-SPACE
-  memory: 1024M
+  memory: 2048M
   path: target/casesvc.jar
   services:
     - DATABASE


### PR DESCRIPTION
# Motivation and Context
Increase the default memory to 2G in the manifest.  The previous size of 1G was insufficient and was causing multiple app crashes.
