### PR TITLE
Remove bi exception

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/CaseService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/CaseService.java
@@ -425,13 +425,13 @@ public class CaseService {
   /**
    * Upfront fail fast validation - if this event is going to require a new case to be created,
    * let's check the request is valid before we do something we cannot rollback ie IAC disable, or
-   * Action creation.
+   * Action creation. This logs the error for info purposes and intentionally doesn't throw an 
+   * exception.
    *
    * @param category the category details
    * @param oldCase the case the event is being created against
-   * @throws CTPException if the CaseEventRequest is invalid
    */
-  private void validateCaseEventRequest(Category category, Case oldCase) throws CTPException {
+  private void validateCaseEventRequest(Category category, Case oldCase) {
     String oldCaseSampleUnitType = oldCase.getSampleUnitType().name();
     String expectedOldCaseSampleUnitTypes = category.getOldCaseSampleUnitTypes();
     if (!compareOldCaseSampleUnitType(oldCaseSampleUnitType, expectedOldCaseSampleUnitTypes)) {
@@ -441,7 +441,6 @@ public class CaseService {
               oldCaseSampleUnitType,
               expectedOldCaseSampleUnitTypes);
       log.error(errorMsg);
-      throw new CTPException(CTPException.Fault.VALIDATION_FAILED, errorMsg);
     }
   }
 

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/CaseService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/CaseService.java
@@ -425,7 +425,7 @@ public class CaseService {
   /**
    * Upfront fail fast validation - if this event is going to require a new case to be created,
    * let's check the request is valid before we do something we cannot rollback ie IAC disable, or
-   * Action creation. This logs the error for info purposes and intentionally doesn't throw an 
+   * Action creation. This logs the error for info purposes and intentionally doesn't throw an
    * exception.
    *
    * @param category the category details

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/service/CaseServiceTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/service/CaseServiceTest.java
@@ -757,40 +757,6 @@ public class CaseServiceTest {
   }
 
   /**
-   * We create a CaseEvent with category RESPONDENT_ENROLED versus a Case of wrong sampleUnitType
-   * (ie NOT a B)
-   *
-   * @throws Exception if fabricateEvent does
-   */
-  @Test
-  public void testEventRespondentEnrolledVersusWrongCaseType() throws Exception {
-    Case existingCase = cases.get(ACTIONABLE_HOUSEHOLD_CASE_FK);
-    when(caseRepo.findOne(ACTIONABLE_HOUSEHOLD_CASE_FK)).thenReturn(existingCase);
-    when(categoryRepo.findOne(CategoryDTO.CategoryName.RESPONDENT_ENROLED))
-        .thenReturn(categories.get(CAT_RESPONDENT_ENROLED));
-
-    CaseEvent caseEvent =
-        fabricateEvent(CategoryDTO.CategoryName.RESPONDENT_ENROLED, ACTIONABLE_HOUSEHOLD_CASE_FK);
-
-    try {
-      caseService.createCaseEvent(caseEvent);
-      fail();
-    } catch (CTPException e) {
-      assertEquals(CTPException.Fault.VALIDATION_FAILED, e.getFault());
-      assertEquals(String.format(WRONG_OLD_SAMPLE_UNIT_TYPE_MSG, "H", "B"), e.getMessage());
-    }
-
-    verify(caseRepo).findOne(ACTIONABLE_HOUSEHOLD_CASE_FK);
-    verify(categoryRepo).findOne(CategoryDTO.CategoryName.RESPONDENT_ENROLED);
-    verify(caseRepo, times(0)).saveAndFlush(any(Case.class));
-    verify(notificationPublisher, times(0)).sendNotification(any(CaseNotification.class));
-    verify(actionSvcClient, times(0))
-        .postAction(any(String.class), any(UUID.class), any(String.class));
-    verify(caseIacAuditService, times(0)).disableAllIACsForCase(any(Case.class));
-    verify(caseEventRepo, times(0)).save(caseEvent);
-  }
-
-  /**
    * We create a CaseEvent with category COLLECTION_INSTRUMENT_DOWNLOADED on an ACTIONABLE BRES case
    * (the one created for a respondent BI, accountant replying on behalf of Tesco for instance)
    *

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/service/CaseServiceTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/service/CaseServiceTest.java
@@ -1,7 +1,6 @@
 package uk.gov.ons.ctp.response.casesvc.service;
 
 import static junit.framework.TestCase.assertNull;
-import static junit.framework.TestCase.fail;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -17,7 +16,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.ons.ctp.response.casesvc.representation.CategoryDTO.CategoryName.EQ_LAUNCH;
-import static uk.gov.ons.ctp.response.casesvc.service.CaseService.WRONG_OLD_SAMPLE_UNIT_TYPE_MSG;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;


### PR DESCRIPTION
# Motivation and Context
Users were getting a 500 error when trying to disable some enrolments this is because an exception was being thrown for a B BI case.

# What has changed
Removed the throw exception for the check.
Removed unnecessary test that was checking for the exception

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
