### PR TITLE
Stopping case service from removing IACs when enrolments get disabled

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/CaseService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/CaseService.java
@@ -291,7 +291,6 @@ public class CaseService {
         generateAndStoreNewIAC(targetCase);
         break;
       case NO_ACTIVE_ENROLMENTS:
-        generateAndStoreNewIAC(targetCase);
         processActionPlanChange(targetCase, false);
         break;
       default:

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/service/CaseServiceTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/service/CaseServiceTest.java
@@ -936,8 +936,7 @@ public class CaseServiceTest {
     verify(categoryRepo).findOne(CategoryName.NO_ACTIVE_ENROLMENTS);
     verify(caseEventRepo, times(1)).save(caseEvent);
     ArgumentCaptor<Case> argument = ArgumentCaptor.forClass(Case.class);
-    verify(caseRepo, times(2)).saveAndFlush(argument.capture());
-    verify(caseRepo, times(2)).saveAndFlush(argument.capture());
+    verify(caseRepo, times(1)).saveAndFlush(argument.capture());
     verify(notificationPublisher, times(1)).sendNotification(any(CaseNotification.class));
   }
 


### PR DESCRIPTION
# Motivation and Context
There are situations where the current behaviour (disabling an enrolment invalidates outstanding IAC codes) is unwanted, so this removes it

# What has changed
Removed the code that did this and changed the test to match