### PR TITLE
Added ability to limit cases by survey, not returning older ones

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/domain/repository/CaseRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/domain/repository/CaseRepository.java
@@ -60,6 +60,14 @@ public interface CaseRepository extends JpaRepository<Case, Integer> {
   List<Case> findByPartyId(UUID partyId);
 
   /**
+   * Find cases assigned to a given partyId ordered by creation date desc
+   *
+   * @param partyId the partyId
+   * @return the cases associated with the partyId
+   */
+  List<Case> findByPartyIdOrderByCreatedDateTimeDesc(UUID partyId);
+
+  /**
    * Find case by its sample unit id
    *
    * @param sampleUnitId

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseEndpoint.java
@@ -132,16 +132,28 @@ public final class CaseEndpoint implements CTPEndpoint {
    * @param partyId to find by
    * @param caseevents flag used to return or not CaseEvents
    * @param iac flag used to return or not the iac
+   * @param max_cases_per_survey the maximum number of collection exercises to return per survey
    * @return the cases found
    */
-  @Deprecated // See findCases(sampleUnitId, partyId)
   @RequestMapping(value = "/partyid/{partyId}", method = RequestMethod.GET)
   public ResponseEntity<List<CaseDetailsDTO>> findCasesByPartyId(
       @PathVariable("partyId") final UUID partyId,
       @RequestParam(value = "caseevents", required = false) final boolean caseevents,
-      @RequestParam(value = "iac", required = false) final boolean iac) {
-    log.with("party_id", partyId).debug("Retrieving cases by party");
-    List<Case> casesList = caseService.findCasesByPartyId(partyId, iac);
+      @RequestParam(value = "iac", required = false) final boolean iac,
+      @RequestParam(value = "max_cases_per_survey", required = false)
+          final Integer maxCasesPerSurvey) {
+
+    List<Case> casesList;
+    if (maxCasesPerSurvey != null) {
+      log.with("party_id", partyId)
+          .with("max_cases_per_survey", maxCasesPerSurvey)
+          .info("Retrieving cases by party");
+      casesList = caseService.findCasesByPartyIdLimitedPerSurvey(partyId, iac, maxCasesPerSurvey);
+
+    } else {
+      log.with("party_id", partyId).info("Retrieving cases by party");
+      casesList = caseService.findCasesByPartyId(partyId, iac);
+    }
 
     if (CollectionUtils.isEmpty(casesList)) {
       return ResponseEntity.noContent().build();


### PR DESCRIPTION
# Motivation and Context
Response ops UI was getting all cases for all surveys for a specific ru , then getting all the details for all the cases , then only showing 12 per survey in the response ops view. This ticket was to restrict the returned cases to be the last n cases per survey. So that the redundant  look ups in the UI where not needed . 

# What has changed
Added an extra parameter on the call. If the parameter is missing the code follows the old route. If t is present then it orders the get case by party by create date descending and then only returns the requested number per survey . So older cases are not returned. Currently the UI sets this to 12 so it can show 12 cases per survey per ru , which is ok for the last year of monthly surveys. (The branch name says pagination as this was the first approach but that did it across all surveys)
 
<!--- What tests have been written -->
Most of the case selection and ordering is via JPA . JPQL could not cope with the complex query needed to implement this in SQL , so a function was added to limit the result set in code as a pragmatic compromise. This was subject to a new unit test

# How to test?
Run acceptance tests to get data in a good state.
look at the collection exercises for an ru with multiple collexes. Stop response ops . Either export MAX_CASES_RETRIEVED_PER_SURVEY = 1 and rerun and verify that only the last collex is shown , or run it in a debugger and manually set it to 1. Verify that the older collexes are the ones dropped,


# Links
https://trello.com/c/IRgw9xaj