### PR TITLE
Create DNS entries for each service

### DIFF
--- a/_infra/helm/case/Chart.yaml
+++ b/_infra/helm/case/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.0
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/_infra/helm/case/templates/deployment.yaml
+++ b/_infra/helm/case/templates/deployment.yaml
@@ -182,25 +182,49 @@ spec:
           - name: DATA_GRID_ADDRESS
             value: "$(REDIS_HOST):$(REDIS_PORT)"
           - name: ACTION_SVC_CONNECTION_CONFIG_HOST
+            {{- if .Values.dns.enabled }}
+            value: "action.{{ .Values.namespace }}.svc.cluster.local"
+            {{- else }}
             value: "$(ACTION_SERVICE_HOST)"
+            {{- end }}
           - name: ACTION_SVC_CONNECTION_CONFIG_PORT
+            {{- if .Values.dns.enabled }}
+            value: "{{ .Values.dns.wellKnownPort }}"
+            {{- else }}
             value: "$(ACTION_SERVICE_PORT)"
+            {{- end }}
           - name: ACTION_SVC_CONNECTION_CONFIG_USERNAME
             value: "$(SECURITY_USER_NAME)"
           - name: ACTION_SVC_CONNECTION_CONFIG_PASSWORD
             value: "$(SECURITY_USER_PASSWORD)"
           - name: INTERNET_ACCESS_CODE_SVC_CONNECTION_CONFIG_HOST
+            {{- if .Values.dns.enabled }}
+            value: "iac.{{ .Values.namespace }}.svc.cluster.local"
+            {{- else }}
             value: "$(IAC_SERVICE_HOST)"
+            {{- end }}
           - name: INTERNET_ACCESS_CODE_SVC_CONNECTION_CONFIG_PORT
+            {{- if .Values.dns.enabled }}
+            value: "{{ .Values.dns.wellKnownPort }}"
+            {{- else }}
             value: "$(IAC_SERVICE_PORT)"
+            {{- end }}
           - name: INTERNET_ACCESS_CODE_SVC_CONNECTION_CONFIG_USERNAME
             value: "$(SECURITY_USER_NAME)"
           - name: INTERNET_ACCESS_CODE_SVC_CONNECTION_CONFIG_PASSWORD
             value: "$(SECURITY_USER_PASSWORD)"
           - name: COLLECTION_EXERCISE_SVC_CONNECTION_CONFIG_HOST
+            {{- if .Values.dns.enabled }}
+            value: "collection-exercise.{{ .Values.namespace }}.svc.cluster.local"
+            {{- else }}
             value: "$(COLLECTION_EXERCISE_SERVICE_HOST)"
+            {{- end }}
           - name: COLLECTION_EXERCISE_SVC_CONNECTION_CONFIG_PORT
+            {{- if .Values.dns.enabled }}
+            value: "{{ .Values.dns.wellKnownPort }}"
+            {{- else }}
             value: "$(COLLECTION_EXERCISE_SERVICE_PORT)"
+            {{- end }}
           - name: COLLECTION_EXERCISE_SVC_CONNECTION_CONFIG_USERNAME
             value: "$(SECURITY_USER_NAME)"
           - name: COLLECTION_EXERCISE_SVC_CONNECTION_CONFIG_PASSWORD

--- a/_infra/helm/case/values.yaml
+++ b/_infra/helm/case/values.yaml
@@ -42,3 +42,7 @@ tomcat:
   maxActive: 10
   maxIdle: 5
   minIdle: 3
+
+dns:
+  enabled: false
+  wellKnownPort: 8080


### PR DESCRIPTION
# Motivation and Context
Adds kube_dns addresses for all connecting services to allow us to have circular references