### PR TITLE
Report scheduler is now configurable

### DIFF
--- a/_infra/helm/case/Chart.yaml
+++ b/_infra/helm/case/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 11.0.6
+appVersion: 11.0.7

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/config/ReportSettings.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/config/ReportSettings.java
@@ -7,5 +7,6 @@ import net.sourceforge.cobertura.CoverageIgnore;
 @CoverageIgnore
 @Data
 public class ReportSettings {
+  private boolean cronEnabled;
   private String cronExpression;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/scheduled/ReportScheduler.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/scheduled/ReportScheduler.java
@@ -6,8 +6,6 @@ import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.context.annotation.Conditional;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import uk.gov.ons.ctp.response.casesvc.service.CaseReportService;
@@ -68,8 +66,8 @@ public class ReportScheduler {
       log.debug("Entering createReport...");
 
       reportDistributedLatchManager.setCountDownLatch(
-              DISTRIBUTED_OBJECT_KEY_REPORT_LATCH,
-              reportDistributedInstanceManager.getInstanceCount(DISTRIBUTED_OBJECT_KEY_INSTANCE_COUNT));
+          DISTRIBUTED_OBJECT_KEY_REPORT_LATCH,
+          reportDistributedInstanceManager.getInstanceCount(DISTRIBUTED_OBJECT_KEY_INSTANCE_COUNT));
 
       if (!reportDistributedLockManager.isLocked(DISTRIBUTED_OBJECT_KEY_REPORT)) {
         if (reportDistributedLockManager.lock(DISTRIBUTED_OBJECT_KEY_REPORT)) {
@@ -79,12 +77,13 @@ public class ReportScheduler {
 
       try {
         reportDistributedLatchManager.countDown(DISTRIBUTED_OBJECT_KEY_REPORT_LATCH);
-        if (!reportDistributedLatchManager.awaitCountDownLatch(DISTRIBUTED_OBJECT_KEY_REPORT_LATCH)) {
+        if (!reportDistributedLatchManager.awaitCountDownLatch(
+            DISTRIBUTED_OBJECT_KEY_REPORT_LATCH)) {
           log.with(
                   "instance_count",
                   reportDistributedInstanceManager.getInstanceCount(
-                          DISTRIBUTED_OBJECT_KEY_INSTANCE_COUNT))
-                  .error("Report run error countdownlatch timed out");
+                      DISTRIBUTED_OBJECT_KEY_INSTANCE_COUNT))
+              .error("Report run error countdownlatch timed out");
         }
       } catch (InterruptedException e) {
         log.error("Report run error waiting for countdownlatch", e);

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/scheduled/ReportScheduler.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/scheduled/ReportScheduler.java
@@ -5,6 +5,9 @@ import com.godaddy.logging.LoggerFactory;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import uk.gov.ons.ctp.response.casesvc.service.CaseReportService;
@@ -23,6 +26,9 @@ public class ReportScheduler {
   private static final String DISTRIBUTED_OBJECT_KEY_INSTANCE_COUNT = "reportscheduler";
   private static final String DISTRIBUTED_OBJECT_KEY_REPORT = "report";
 
+  @Value("#{appConfig.reportSettings.cronEnabled}")
+  private boolean reportEnabled;
+
   @Autowired private CaseReportService caseReportService;
 
   @Autowired private DistributedLockManager reportDistributedLockManager;
@@ -34,6 +40,7 @@ public class ReportScheduler {
   /** Initialise report scheduler */
   @PostConstruct
   public void init() {
+    log.debug("Report Schedule enabled: " + reportEnabled);
     reportDistributedInstanceManager.incrementInstanceCount(DISTRIBUTED_OBJECT_KEY_INSTANCE_COUNT);
     log.with(
             "instance_count",
@@ -57,32 +64,34 @@ public class ReportScheduler {
   /** The method triggering report creation. */
   @Scheduled(cron = "#{appConfig.reportSettings.cronExpression}")
   public void createReport() {
-    log.debug("Entering createReport...");
+    if (reportEnabled) {
+      log.debug("Entering createReport...");
 
-    reportDistributedLatchManager.setCountDownLatch(
-        DISTRIBUTED_OBJECT_KEY_REPORT_LATCH,
-        reportDistributedInstanceManager.getInstanceCount(DISTRIBUTED_OBJECT_KEY_INSTANCE_COUNT));
+      reportDistributedLatchManager.setCountDownLatch(
+              DISTRIBUTED_OBJECT_KEY_REPORT_LATCH,
+              reportDistributedInstanceManager.getInstanceCount(DISTRIBUTED_OBJECT_KEY_INSTANCE_COUNT));
 
-    if (!reportDistributedLockManager.isLocked(DISTRIBUTED_OBJECT_KEY_REPORT)) {
-      if (reportDistributedLockManager.lock(DISTRIBUTED_OBJECT_KEY_REPORT)) {
-        caseReportService.createReport();
+      if (!reportDistributedLockManager.isLocked(DISTRIBUTED_OBJECT_KEY_REPORT)) {
+        if (reportDistributedLockManager.lock(DISTRIBUTED_OBJECT_KEY_REPORT)) {
+          caseReportService.createReport();
+        }
       }
-    }
 
-    try {
-      reportDistributedLatchManager.countDown(DISTRIBUTED_OBJECT_KEY_REPORT_LATCH);
-      if (!reportDistributedLatchManager.awaitCountDownLatch(DISTRIBUTED_OBJECT_KEY_REPORT_LATCH)) {
-        log.with(
-                "instance_count",
-                reportDistributedInstanceManager.getInstanceCount(
-                    DISTRIBUTED_OBJECT_KEY_INSTANCE_COUNT))
-            .error("Report run error countdownlatch timed out");
+      try {
+        reportDistributedLatchManager.countDown(DISTRIBUTED_OBJECT_KEY_REPORT_LATCH);
+        if (!reportDistributedLatchManager.awaitCountDownLatch(DISTRIBUTED_OBJECT_KEY_REPORT_LATCH)) {
+          log.with(
+                  "instance_count",
+                  reportDistributedInstanceManager.getInstanceCount(
+                          DISTRIBUTED_OBJECT_KEY_INSTANCE_COUNT))
+                  .error("Report run error countdownlatch timed out");
+        }
+      } catch (InterruptedException e) {
+        log.error("Report run error waiting for countdownlatch", e);
+      } finally {
+        reportDistributedLockManager.unlock(DISTRIBUTED_OBJECT_KEY_REPORT);
+        reportDistributedLatchManager.deleteCountDownLatch(DISTRIBUTED_OBJECT_KEY_REPORT_LATCH);
       }
-    } catch (InterruptedException e) {
-      log.error("Report run error waiting for countdownlatch", e);
-    } finally {
-      reportDistributedLockManager.unlock(DISTRIBUTED_OBJECT_KEY_REPORT);
-      reportDistributedLatchManager.deleteCountDownLatch(DISTRIBUTED_OBJECT_KEY_REPORT_LATCH);
     }
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,7 +19,7 @@ liquibase:
   user: postgres
   password: postgres
   default-schema: casesvc
-  url: jdbc:postgresql://localhost:6432/postgres
+  url: jdbc:postgresql://localhost:5432/postgres
   changeLog: classpath:/database/changelog-master.yml
 
 security:
@@ -55,7 +55,7 @@ spring:
   application:
     name: ONS CaseService
   datasource:
-    url: jdbc:postgresql://localhost:6432/postgres
+    url: jdbc:postgresql://localhost:5432/postgres
     username: postgres
     password: postgres
     driverClassName: org.postgresql.Driver
@@ -75,7 +75,7 @@ spring:
         default_schema: casesvc
 
 data-grid:
-  address: localhost:7379
+  address: localhost:6379
   list-time-to-live-seconds: 60
   list-time-to-wait-seconds: 60
   report-lock-time-to-live-seconds: 300
@@ -125,7 +125,7 @@ rabbitmq:
   username: guest
   password: guest
   host: localhost
-  port: 6672
+  port: 5672
   virtualhost: /
 
 messaging:
@@ -140,6 +140,7 @@ messaging:
 
 report-settings:
   cron-expression: "0 * * * * *"
+  cron-enabled: false
 
 swagger-settings:
   swagger-ui-active: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -140,7 +140,7 @@ messaging:
 
 report-settings:
   cron-expression: "0 * * * * *"
-  cron-enabled: false
+  cron-enabled: true
 
 swagger-settings:
   swagger-ui-active: true


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Making report scheduler configurable to allow us to disable dynamically

Also setting ports on the application yaml to match the new `ras port-forward` command rather than `ras-rm-docker-dev`


# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
