### PR TITLE
Case service incorrectly configured

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,11 +4,13 @@ name: Build
 # events but only for the master branch
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
     paths-ignore: 
       - _infra/spinnaker/**
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
     paths-ignore: 
       - _infra/spinnaker/**
 env:
@@ -46,9 +48,8 @@ jobs:
       - name: Run Tests
         run: |
           mvn clean verify
-      - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+      - uses: google-github-actions/setup-gcloud@master
         with:
-          version: '270.0.0'
           service_account_key: ${{ secrets.GCR_KEY }}
         # Configure docker to use the gcloud command-line tool as a credential helper
       - run: |

--- a/_infra/helm/case/Chart.yaml
+++ b/_infra/helm/case/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 11.1.25
+appVersion: 11.1.26

--- a/_infra/helm/case/templates/deployment.yaml
+++ b/_infra/helm/case/templates/deployment.yaml
@@ -255,5 +255,11 @@ spec:
             value: "{{ .Values.tomcat.minIdle }}"
           - name: ACTION_SVC_DEPRECATED
             value: "{{ .Values.deprecateAction }}"
+          - name: CASE_DISTRIBUTION_RETRIEVAL_MAX
+            value: "{{ .Values.caseDistribution.retrievalMax }}"
+          - name: CASE_DISTRIBUTION_DELAY_MILLI_SECONDS
+            value: "{{ .Values.caseDistribution.delayMilliSeconds }}"
+          - name: MESSAGING_CONSUMING_THREADS
+            value: "{{ .Values.messaging.consumingThreads }}"
           resources:
             {{- toYaml .Values.resources.application | nindent 12 }}

--- a/_infra/helm/case/values.yaml
+++ b/_infra/helm/case/values.yaml
@@ -66,3 +66,10 @@ dns:
   wellKnownPort: 8080
 
 deprecateAction: false
+
+caseDistribution:
+  retrievalMax: 1000
+  delayMilliSeconds: 500
+
+messaging:
+  consumingThreads: 100

--- a/_infra/helm/case/values.yaml
+++ b/_infra/helm/case/values.yaml
@@ -72,4 +72,4 @@ caseDistribution:
   delayMilliSeconds: 500
 
 messaging:
-  consumingThreads: 100
+  consumingThreads: 10


### PR DESCRIPTION
The case service was incorrectly configured to process only 50 cases every .5 seconds and the rabbit queue is only using a single thread as consuming threads.
changes to case distribution process count and delay and rabbit queue consuming threads. This is it now configurable as a part of the deployment.

