### PR TITLE
GCR images for integration tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,11 +46,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: GCR setup
+      - name: gcloud setup
         uses: google-github-actions/setup-gcloud@master
         with:
           service_account_key: ${{ secrets.GCR_KEY }}
         # Configure docker to use the gcloud command-line tool as a credential helper
+      - name: Configure GCR
         run: |
           gcloud auth configure-docker
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,8 @@ jobs:
 
       - name: Run Tests
         run: |
-          export LD_LIBRARY_PATH=/usr/local/lib mvn clean verify
+          export LD_LIBRARY_PATH=/usr/local/lib
+          mvn clean verify
 
       - name: pr docker tag
         if: github.ref != 'refs/heads/main'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           service_account_key: ${{ secrets.GCR_KEY }}
         # Configure docker to use the gcloud command-line tool as a credential helper
-      - run: |
+        run: |
           gcloud auth configure-docker
 
       - name: Run Tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,12 +53,11 @@ jobs:
         # Configure docker to use the gcloud command-line tool as a credential helper
       - name: Configure GCR
         run: |
-          export LD_LIBRARY_PATH=/usr/local/lib
           gcloud auth configure-docker
 
       - name: Run Tests
         run: |
-          mvn clean verify
+          export LD_LIBRARY_PATH=/usr/local/lib mvn clean verify
 
       - name: pr docker tag
         if: github.ref != 'refs/heads/main'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,6 +53,7 @@ jobs:
         # Configure docker to use the gcloud command-line tool as a credential helper
       - name: Configure GCR
         run: |
+          export LD_LIBRARY_PATH=/usr/local/lib
           gcloud auth configure-docker
 
       - name: Run Tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: GCR setup
-      - uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@master
         with:
           service_account_key: ${{ secrets.GCR_KEY }}
         # Configure docker to use the gcloud command-line tool as a credential helper

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,15 +46,17 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Run Tests
-        run: |
-          mvn clean verify
+      - name: GCR setup
       - uses: google-github-actions/setup-gcloud@master
         with:
           service_account_key: ${{ secrets.GCR_KEY }}
         # Configure docker to use the gcloud command-line tool as a credential helper
       - run: |
           gcloud auth configure-docker
+
+      - name: Run Tests
+        run: |
+          mvn clean verify
 
       - name: pr docker tag
         if: github.ref != 'refs/heads/main'

--- a/_infra/helm/case/Chart.yaml
+++ b/_infra/helm/case/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 11.1.34
+appVersion: 11.1.35

--- a/_infra/helm/case/Chart.yaml
+++ b/_infra/helm/case/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 11.1.35
+appVersion: 11.1.36

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     - postgres-case-it
     - redis-case-it
     - rabbitmq-case-it
-    image: eu.gcr.io/ons-rasrmbs-management/collection-exercise:11.1.0
+    image: eu.gcr.io/ons-rasrmbs-management/collection-exercise
     environment:
     - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres-case-it:5432/postgres?sslmode=disable
     - SPRING_DATASOURCE_USERNAME=postgres
@@ -52,7 +52,7 @@ services:
 
   survey:
     container_name: survey-case-it
-    image: eu.gcr.io/ons-rasrmbs-management/survey:11.0.24
+    image: eu.gcr.io/ons-rasrmbs-management/survey
     external_links:
     - postgres-case-it
     environment:
@@ -65,7 +65,7 @@ services:
 
   action:
     container_name: action-case-it
-    image: eu.gcr.io/ons-rasrmbs-management/action:12.3.21
+    image: eu.gcr.io/ons-rasrmbs-management/action
     external_links:
     - postgres-case-it
     - rabbitmq-case-it

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     - postgres-case-it
     - redis-case-it
     - rabbitmq-case-it
-    image: sdcplatform/collectionexercisesvc
+    image: eu.gcr.io/ons-rasrmbs-management/collection-exercise:11.0.50
     environment:
     - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres-case-it:5432/postgres?sslmode=disable
     - SPRING_DATASOURCE_USERNAME=postgres
@@ -52,7 +52,7 @@ services:
 
   survey:
     container_name: survey-case-it
-    image: sdcplatform/surveysvc
+    image: eu.gcr.io/ons-rasrmbs-management/survey:
     external_links:
     - postgres-case-it
     environment:
@@ -65,7 +65,7 @@ services:
 
   action:
     container_name: action-case-it
-    image: sdcplatform/actionsvc
+    image: eu.gcr.io/ons-rasrmbs-management/action:
     external_links:
     - postgres-case-it
     - rabbitmq-case-it

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,14 +26,14 @@ services:
     - postgres-case-it
     - redis-case-it
     - rabbitmq-case-it
-    image: eu.gcr.io/ons-rasrmbs-management/collection-exercise:11.0.50
+    image: eu.gcr.io/ons-rasrmbs-management/collection-exercise:11.1.0
     environment:
     - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres-case-it:5432/postgres?sslmode=disable
     - SPRING_DATASOURCE_USERNAME=postgres
     - SPRING_DATASOURCE_PASSWORD=postgres
-    - LIQUIBASE_URL=jdbc:postgresql://postgres-case-it:5432/postgres
-    - LIQUIBASE_USER=postgres
-    - LIQUIBASE_PASSWORD=postgres
+    - SPRING_LIQUIBASE_URL=jdbc:postgresql://postgres-case-it:5432/postgres
+    - SPRING_LIQUIBASE_USER=postgres
+    - SPRING_LIQUIBASE_PASSWORD=postgres
     - REDISSON_CONFIG_ADDRESS=redis-case-it:6379
     - DATA_GRID_ADDRESS=redis-case-it:6379
     - RABBITMQ_HOST=rabbitmq-case-it
@@ -45,14 +45,14 @@ services:
     ports:
     - "38145:8145"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8145/info"]
+      test: ["CMD", "curl", "-f", "http://localhost:8145/actuator/info"]
       interval: 30s
       timeout: 10s
       retries: 10
 
   survey:
     container_name: survey-case-it
-    image: eu.gcr.io/ons-rasrmbs-management/survey:
+    image: eu.gcr.io/ons-rasrmbs-management/survey:11.0.24
     external_links:
     - postgres-case-it
     environment:
@@ -65,7 +65,7 @@ services:
 
   action:
     container_name: action-case-it
-    image: eu.gcr.io/ons-rasrmbs-management/action:
+    image: eu.gcr.io/ons-rasrmbs-management/action:12.3.21
     external_links:
     - postgres-case-it
     - rabbitmq-case-it
@@ -74,9 +74,9 @@ services:
     - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres-case-it:5432/postgres?sslmode=disable
     - SPRING_DATASOURCE_USERNAME=postgres
     - SPRING_DATASOURCE_PASSWORD=postgres
-    - LIQUIBASE_URL=jdbc:postgresql://postgres-case-it:5432/postgres
-    - LIQUIBASE_USER=postgres
-    - LIQUIBASE_PASSWORD=postgres
+    - SPRING_LIQUIBASE_URL=jdbc:postgresql://postgres-case-it:5432/postgres
+    - SPRING_LIQUIBASE_USER=postgres
+    - SPRING_LIQUIBASE_PASSWORD=postgres
     - REDISSON_CONFIG_ADDRESS=redis-case-it:6379
     - DATA_GRID_ADDRESS=redis-case-it:6379
     - RABBITMQ_HOST=rabbitmq-case-it
@@ -88,15 +88,7 @@ services:
     ports:
     - "38151:8151"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8151/info"]
+      test: ["CMD", "curl", "-f", "http://localhost:8151/actuator/info"]
       interval: 30s
       timeout: 10s
       retries: 10
-
-  start_dependencies:
-    image: dadarek/wait-for-dependencies
-    depends_on:
-      collectionexercise:
-        condition: service_healthy
-      action:
-        condition: service_healthy

--- a/pom.xml
+++ b/pom.xml
@@ -313,58 +313,42 @@
 
         <plugins>
             <plugin>
-                <groupId>io.fabric8</groupId>
-                <artifactId>docker-maven-plugin</artifactId>
-                <version>0.35.0</version>
+                <groupId>com.dkanejs.maven.plugins</groupId>
+                <artifactId>docker-compose-maven-plugin</artifactId>
+                <version>2.0.1</version>
                 <executions>
                     <execution>
                         <id>pre-stop</id>
-                        <goals>
-                            <goal>stop</goal>
-                        </goals>
                         <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>down</goal>
+                        </goals>
                         <configuration>
-                            <images>
-                                <image>
-                                    <external>
-                                        <type>compose</type>
-                                        <basedir>${project.basedir}</basedir>
-                                    </external>
-                                </image>
-                            </images>
+                            <composeFile>${project.basedir}/docker-compose.yml</composeFile>
+                            <skip>${dockerComposeSkip}</skip>
                         </configuration>
                     </execution>
                     <execution>
-                        <id>start</id>
+                        <id>up</id>
+                        <phase>pre-integration-test</phase>
                         <goals>
-                            <goal>start</goal>
+                            <goal>up</goal>
                         </goals>
                         <configuration>
-                            <showLogs>false</showLogs>
-                            <images>
-                                <image>
-                                    <external>
-                                        <type>compose</type>
-                                        <basedir>${project.basedir}</basedir>
-                                    </external>
-                                </image>
-                            </images>
+                            <composeFile>${project.basedir}/docker-compose.yml</composeFile>
+                            <detachedMode>true</detachedMode>
+                            <skip>${dockerComposeSkip}</skip>
                         </configuration>
                     </execution>
                     <execution>
-                        <id>stop</id>
+                        <id>down</id>
+                        <phase>post-integration-test</phase>
                         <goals>
-                            <goal>stop</goal>
+                            <goal>down</goal>
                         </goals>
                         <configuration>
-                            <images>
-                                <image>
-                                    <external>
-                                        <type>compose</type>
-                                        <basedir>${project.basedir}</basedir>
-                                    </external>
-                                </image>
-                            </images>
+                            <composeFile>${project.basedir}/docker-compose.yml</composeFile>
+                            <skip>${dockerComposeSkip}</skip>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -315,7 +315,7 @@
             <plugin>
                 <groupId>io.fabric8</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
-                <version>0.23.0</version>
+                <version>0.35.0</version>
                 <executions>
                     <execution>
                         <id>pre-stop</id>

--- a/pom.xml
+++ b/pom.xml
@@ -313,42 +313,58 @@
 
         <plugins>
             <plugin>
-                <groupId>com.dkanejs.maven.plugins</groupId>
-                <artifactId>docker-compose-maven-plugin</artifactId>
-                <version>2.0.1</version>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <version>0.23.0</version>
                 <executions>
                     <execution>
                         <id>pre-stop</id>
-                        <phase>pre-integration-test</phase>
                         <goals>
-                            <goal>down</goal>
+                            <goal>stop</goal>
                         </goals>
+                        <phase>pre-integration-test</phase>
                         <configuration>
-                            <composeFile>${project.basedir}/docker-compose.yml</composeFile>
-                            <skip>${dockerComposeSkip}</skip>
+                            <images>
+                                <image>
+                                    <external>
+                                        <type>compose</type>
+                                        <basedir>${project.basedir}</basedir>
+                                    </external>
+                                </image>
+                            </images>
                         </configuration>
                     </execution>
                     <execution>
-                        <id>up</id>
-                        <phase>pre-integration-test</phase>
+                        <id>start</id>
                         <goals>
-                            <goal>up</goal>
+                            <goal>start</goal>
                         </goals>
                         <configuration>
-                            <composeFile>${project.basedir}/docker-compose.yml</composeFile>
-                            <detachedMode>true</detachedMode>
-                            <skip>${dockerComposeSkip}</skip>
+                            <showLogs>false</showLogs>
+                            <images>
+                                <image>
+                                    <external>
+                                        <type>compose</type>
+                                        <basedir>${project.basedir}</basedir>
+                                    </external>
+                                </image>
+                            </images>
                         </configuration>
                     </execution>
                     <execution>
-                        <id>down</id>
-                        <phase>post-integration-test</phase>
+                        <id>stop</id>
                         <goals>
-                            <goal>down</goal>
+                            <goal>stop</goal>
                         </goals>
                         <configuration>
-                            <composeFile>${project.basedir}/docker-compose.yml</composeFile>
-                            <skip>${dockerComposeSkip}</skip>
+                            <images>
+                                <image>
+                                    <external>
+                                        <type>compose</type>
+                                        <basedir>${project.basedir}</basedir>
+                                    </external>
+                                </image>
+                            </images>
                         </configuration>
                     </execution>
                 </executions>
@@ -385,33 +401,6 @@
                         <goals>
                             <goal>repackage</goal>
                         </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
-                <version>1.4.4</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>javax.activation</groupId>
-                        <artifactId>javax.activation-api</artifactId>
-                        <version>1.2.0</version>
-                        <scope>compile</scope>
-                    </dependency>
-                </dependencies>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>build</goal>
-                        </goals>
-                        <phase>package</phase>
-                        <configuration>
-                            <repository>sdcplatform/${project.artifactId}</repository>
-                            <buildArgs>
-                                <JAR_FILE>${project.build.finalName}.jar</JAR_FILE>
-                            </buildArgs>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -325,7 +325,6 @@
                         </goals>
                         <configuration>
                             <composeFile>${project.basedir}/docker-compose.yml</composeFile>
-                            <skip>${dockerComposeSkip}</skip>
                         </configuration>
                     </execution>
                     <execution>
@@ -337,7 +336,6 @@
                         <configuration>
                             <composeFile>${project.basedir}/docker-compose.yml</composeFile>
                             <detachedMode>true</detachedMode>
-                            <skip>${dockerComposeSkip}</skip>
                         </configuration>
                     </execution>
                     <execution>
@@ -348,7 +346,6 @@
                         </goals>
                         <configuration>
                             <composeFile>${project.basedir}/docker-compose.yml</composeFile>
-                            <skip>${dockerComposeSkip}</skip>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
# What and why?
For the integration tests use up to date GCR images and not the old ones from docker hub

# How to test?
Run `mvn clean install`

# Trello
N/A