### PR TITLE
Docker tag latest at the same time as the release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,13 +6,9 @@ on:
   push:
     branches:
       - main
-    paths-ignore: 
-      - _infra/spinnaker/**
   pull_request:
     branches:
       - main
-    paths-ignore: 
-      - _infra/spinnaker/**
 
 env:
   IMAGE: case
@@ -143,12 +139,13 @@ jobs:
       - name: Build Release Image
         if: github.ref == 'refs/heads/main'
         run: |
-          docker build -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":${{ steps.release.outputs.version }} .
+          docker build -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":latest -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":${{ steps.release.outputs.version }} .
       - name: Push Release image
         if: github.ref == 'refs/heads/main'
         run: |
           docker push "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":${{ steps.release.outputs.version }}
-      
+          docker push "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":latest
+
       - name: Publish Charts
         if: github.ref == 'refs/heads/main'
         run: |

--- a/_infra/helm/case/Chart.yaml
+++ b/_infra/helm/case/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 11.1.34
+appVersion: 11.1.35


### PR DESCRIPTION
# What and why?
During the release step tag the generated docker image as both the release version and latest.

# How to test?

# Trello
