### PR TITLE
Fix pubsub receipting issue

### DIFF
--- a/_infra/helm/case/Chart.yaml
+++ b/_infra/helm/case/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 11.1.47
+version: 11.1.48
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 11.1.47
+appVersion: 11.1.48

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/message/CaseReceiptPubSubSubscription.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/message/CaseReceiptPubSubSubscription.java
@@ -54,10 +54,14 @@ public class CaseReceiptPubSubSubscription {
         try {
           caseReceiptReceiver.process(receipt);
         } catch (CTPException e) {
-          log.error(e, "Error processing receipt");
+          log.with("message", e.getMessage())
+              .with("stacktrace", e.getStackTrace())
+              .error(e, "Error processing receipt");
           consumer.nack();
         } catch (Exception e) {
-          log.error(e, "Unexpected error processing receipt");
+          log.with("message", e.getMessage())
+              .with("stacktrace", e.getStackTrace())
+              .error(e, "Unexpected error processing receipt");
           consumer.nack();
         }
         consumer.ack();

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/message/CaseReceiptPubSubSubscription.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/message/CaseReceiptPubSubSubscription.java
@@ -52,6 +52,7 @@ public class CaseReceiptPubSubSubscription {
         CaseReceipt receipt = mapper.readValue(payload, CaseReceipt.class);
         log.with("receipt", receipt).debug("Successfully serialised receipt");
         try {
+          log.info(caseReceiptReceiver.toString());
           caseReceiptReceiver.process(receipt);
         } catch (CTPException e) {
           log.with("message", e.getMessage())

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/message/CaseReceiptPubSubSubscription.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/message/CaseReceiptPubSubSubscription.java
@@ -52,7 +52,6 @@ public class CaseReceiptPubSubSubscription {
         CaseReceipt receipt = mapper.readValue(payload, CaseReceipt.class);
         log.with("receipt", receipt).debug("Successfully serialised receipt");
         try {
-          log.info(caseReceiptReceiver.toString());
           caseReceiptReceiver.process(receipt);
         } catch (CTPException e) {
           log.error(e, "Error processing receipt");

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/message/CaseReceiptPubSubSubscription.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/message/CaseReceiptPubSubSubscription.java
@@ -54,15 +54,15 @@ public class CaseReceiptPubSubSubscription {
         try {
           caseReceiptReceiver.process(receipt);
         } catch (CTPException e) {
-          log.error("Error processing receipt", e);
+          log.error(e, "Error processing receipt");
           consumer.nack();
         } catch (Exception e) {
-          log.error("Unexpected error processing receipt", e);
+          log.error(e, "Unexpected error processing receipt");
           consumer.nack();
         }
         consumer.ack();
       } catch (JsonProcessingException e) {
-        log.error("Error serialising receipt.", e);
+        log.error(e, "Error serialising receipt.");
         consumer.nack();
       }
     };

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/message/CaseReceiptPubSubSubscription.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/message/CaseReceiptPubSubSubscription.java
@@ -55,14 +55,10 @@ public class CaseReceiptPubSubSubscription {
           log.info(caseReceiptReceiver.toString());
           caseReceiptReceiver.process(receipt);
         } catch (CTPException e) {
-          log.with("message", e.getMessage())
-              .with("stacktrace", e.getStackTrace())
-              .error(e, "Error processing receipt");
+          log.error(e, "Error processing receipt");
           consumer.nack();
         } catch (Exception e) {
-          log.with("message", e.getMessage())
-              .with("stacktrace", e.getStackTrace())
-              .error(e, "Unexpected error processing receipt");
+          log.error(e, "Unexpected error processing receipt");
           consumer.nack();
         }
         consumer.ack();

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/message/CaseReceiptReceiver.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/message/CaseReceiptReceiver.java
@@ -55,6 +55,7 @@ public class CaseReceiptReceiver {
     log.with("existing_case", existingCase).info("Found existing case");
 
     CategoryDTO.CategoryName category = null;
+    log.with("inboundChannel", inboundChannel).info("just before switch");
     switch (inboundChannel) {
       case OFFLINE:
         category = OFFLINE_RESPONSE_PROCESSED;
@@ -68,6 +69,7 @@ public class CaseReceiptReceiver {
       default:
         break;
     }
+    log.with("category", category).info("After switch");
 
     if (existingCase == null) {
       log.with("case_id", caseId).error(EXISTING_CASE_NOT_FOUND);
@@ -81,6 +83,7 @@ public class CaseReceiptReceiver {
         caseEvent.setMetadata(metadata);
       }
       caseEvent.setCaseFK(existingCase.getCasePK());
+      log.info("Just before setting category");
       caseEvent.setCategory(category);
       log.with("case_event", caseEvent.getCategory()).info("New case event");
       caseEvent.setCreatedBy(SYSTEM);

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/message/CaseReceiptReceiver.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/message/CaseReceiptReceiver.java
@@ -47,7 +47,7 @@ public class CaseReceiptReceiver {
     Timestamp responseTimestamp = dateTimeUtil.getNowUTC();
 
     Case existingCase = caseService.findCaseById(caseId);
-    log.with("existing_case", existingCase).info("Found existing case");
+    log.with("existing_case", existingCase).debug("Found existing case");
 
     if (existingCase == null) {
       log.with("case_id", caseId).error(EXISTING_CASE_NOT_FOUND);

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/message/CaseReceiptReceiver.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/message/CaseReceiptReceiver.java
@@ -52,7 +52,7 @@ public class CaseReceiptReceiver {
     Timestamp responseTimestamp = dateTimeUtil.getNowUTC();
 
     Case existingCase = caseService.findCaseById(caseId);
-    log.with("existing_case", existingCase).debug("Found existing case");
+    log.with("existing_case", existingCase).info("Found existing case");
 
     CategoryDTO.CategoryName category = null;
     switch (inboundChannel) {
@@ -75,6 +75,7 @@ public class CaseReceiptReceiver {
       CaseEvent caseEvent = new CaseEvent();
       String partyId = caseReceipt.getPartyId();
       if (partyId != null && !partyId.isEmpty()) {
+        log.info("we've got a partyid");
         Map<String, String> metadata = new HashMap<>();
         metadata.put("partyId", partyId);
         caseEvent.setMetadata(metadata);
@@ -84,7 +85,7 @@ public class CaseReceiptReceiver {
       log.with("case_event", caseEvent.getCategory()).info("New case event");
       caseEvent.setCreatedBy(SYSTEM);
       caseEvent.setDescription(QUESTIONNAIRE_RESPONSE);
-      log.debug("about to invoke the event creation...");
+      log.info("about to invoke the event creation...");
       caseService.createCaseEvent(caseEvent, responseTimestamp);
     }
   }

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/message/CaseReceiptReceiver.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/message/CaseReceiptReceiver.java
@@ -64,7 +64,7 @@ public class CaseReceiptReceiver {
       log.with("case_event", caseEvent.getCategory()).info("New case event");
       caseEvent.setCreatedBy(SYSTEM);
       caseEvent.setDescription(QUESTIONNAIRE_RESPONSE);
-      log.info("about to invoke the event creation...");
+      log.debug("about to invoke the event creation...");
       caseService.createCaseEvent(caseEvent, responseTimestamp);
     }
   }

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/message/CaseReceiptReceiver.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/message/CaseReceiptReceiver.java
@@ -1,8 +1,6 @@
 package uk.gov.ons.ctp.response.casesvc.message;
 
 import static uk.gov.ons.ctp.response.casesvc.representation.CategoryDTO.CategoryName.OFFLINE_RESPONSE_PROCESSED;
-import static uk.gov.ons.ctp.response.casesvc.representation.CategoryDTO.CategoryName.ONLINE_QUESTIONNAIRE_RESPONSE;
-import static uk.gov.ons.ctp.response.casesvc.representation.CategoryDTO.CategoryName.PAPER_QUESTIONNAIRE_RESPONSE;
 import static uk.gov.ons.ctp.response.casesvc.utility.Constants.QUESTIONNAIRE_RESPONSE;
 import static uk.gov.ons.ctp.response.casesvc.utility.Constants.SYSTEM;
 
@@ -20,8 +18,6 @@ import org.springframework.transaction.annotation.Transactional;
 import uk.gov.ons.ctp.response.casesvc.domain.model.Case;
 import uk.gov.ons.ctp.response.casesvc.domain.model.CaseEvent;
 import uk.gov.ons.ctp.response.casesvc.message.feedback.CaseReceipt;
-import uk.gov.ons.ctp.response.casesvc.message.feedback.InboundChannel;
-import uk.gov.ons.ctp.response.casesvc.representation.CategoryDTO;
 import uk.gov.ons.ctp.response.casesvc.service.CaseService;
 import uk.gov.ons.ctp.response.lib.common.error.CTPException;
 import uk.gov.ons.ctp.response.lib.common.time.DateTimeUtil;
@@ -43,33 +39,15 @@ public class CaseReceiptReceiver {
    * @param caseReceipt to process
    * @throws CTPException CTPException
    */
-  @Transactional(propagation = Propagation.REQUIRED, readOnly = false, value = "transactionManager")
+  @Transactional(propagation = Propagation.REQUIRED, value = "transactionManager")
   @ServiceActivator(inputChannel = "caseReceiptTransformed", adviceChain = "caseReceiptRetryAdvice")
   public void process(CaseReceipt caseReceipt) throws CTPException {
     log.with("case_receipt", caseReceipt).debug("entering process with caseReceipt");
     UUID caseId = UUID.fromString(caseReceipt.getCaseId());
-    InboundChannel inboundChannel = caseReceipt.getInboundChannel();
     Timestamp responseTimestamp = dateTimeUtil.getNowUTC();
 
     Case existingCase = caseService.findCaseById(caseId);
     log.with("existing_case", existingCase).info("Found existing case");
-
-    CategoryDTO.CategoryName category = null;
-    log.with("inboundChannel", inboundChannel).info("just before switch");
-    switch (inboundChannel) {
-      case OFFLINE:
-        category = OFFLINE_RESPONSE_PROCESSED;
-        break;
-      case ONLINE:
-        category = ONLINE_QUESTIONNAIRE_RESPONSE;
-        break;
-      case PAPER:
-        category = PAPER_QUESTIONNAIRE_RESPONSE;
-        break;
-      default:
-        break;
-    }
-    log.with("category", category).info("After switch");
 
     if (existingCase == null) {
       log.with("case_id", caseId).error(EXISTING_CASE_NOT_FOUND);
@@ -77,14 +55,12 @@ public class CaseReceiptReceiver {
       CaseEvent caseEvent = new CaseEvent();
       String partyId = caseReceipt.getPartyId();
       if (partyId != null && !partyId.isEmpty()) {
-        log.info("we've got a partyid");
         Map<String, String> metadata = new HashMap<>();
         metadata.put("partyId", partyId);
         caseEvent.setMetadata(metadata);
       }
       caseEvent.setCaseFK(existingCase.getCasePK());
-      log.info("Just before setting category");
-      caseEvent.setCategory(category);
+      caseEvent.setCategory(OFFLINE_RESPONSE_PROCESSED);
       log.with("case_event", caseEvent.getCategory()).info("New case event");
       caseEvent.setCreatedBy(SYSTEM);
       caseEvent.setDescription(QUESTIONNAIRE_RESPONSE);

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/CaseService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/CaseService.java
@@ -305,7 +305,7 @@ public class CaseService {
    */
   public CaseEvent createCaseEvent(final CaseEvent caseEvent, final Timestamp timestamp)
       throws CTPException {
-    log.with("case_event", caseEvent).debug("Creating case event");
+    log.with("case_event", caseEvent).info("Creating case event");
 
     Case targetCase = caseRepo.findById(caseEvent.getCaseFK()).orElse(null);
     log.with("target_case", targetCase).debug("Found target case");

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/message/CaseReceiptReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/message/CaseReceiptReceiverTest.java
@@ -5,8 +5,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static uk.gov.ons.ctp.response.casesvc.representation.CategoryDTO.CategoryName.OFFLINE_RESPONSE_PROCESSED;
-import static uk.gov.ons.ctp.response.casesvc.representation.CategoryDTO.CategoryName.ONLINE_QUESTIONNAIRE_RESPONSE;
-import static uk.gov.ons.ctp.response.casesvc.representation.CategoryDTO.CategoryName.PAPER_QUESTIONNAIRE_RESPONSE;
 import static uk.gov.ons.ctp.response.casesvc.utility.Constants.QUESTIONNAIRE_RESPONSE;
 import static uk.gov.ons.ctp.response.casesvc.utility.Constants.SYSTEM;
 
@@ -76,7 +74,7 @@ public class CaseReceiptReceiverTest {
     metadata.put("partyId", LINKED_PARTY_ID);
     verify(caseService, times(1))
         .createCaseEvent(
-            eq(buildCaseEvent(LINKED_CASE_PK, ONLINE_QUESTIONNAIRE_RESPONSE, metadata)),
+            eq(buildCaseEvent(LINKED_CASE_PK, OFFLINE_RESPONSE_PROCESSED, metadata)),
             eq(new Timestamp(CURRENT_TIME_IN_MILLISECONDS)));
   }
 
@@ -102,7 +100,7 @@ public class CaseReceiptReceiverTest {
 
     verify(caseService, times(1))
         .createCaseEvent(
-            eq(buildCaseEvent(LINKED_CASE_PK, PAPER_QUESTIONNAIRE_RESPONSE, metadata)),
+            eq(buildCaseEvent(LINKED_CASE_PK, OFFLINE_RESPONSE_PROCESSED, metadata)),
             eq(new Timestamp(CURRENT_TIME_IN_MILLISECONDS)));
   }
 


### PR DESCRIPTION
# What and why?

When a SDX GCP receipt comes through via pubsub, it was throwing an error because the inboundChannel wasn't being set.
This PR fixes that by hardcoding the event category, that the inboundChannel was influencing, because it was always the same anyway 

# How to test?

# Trello
