### PR TITLE
Fix sql

### DIFF
--- a/_infra/helm/case/Chart.yaml
+++ b/_infra/helm/case/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 11.1.49
+version: 11.1.50
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 11.1.49
+appVersion: 11.1.50

--- a/src/main/resources/database/changes/release-28/remove_unused_categories.sql
+++ b/src/main/resources/database/changes/release-28/remove_unused_categories.sql
@@ -1,17 +1,50 @@
+DELETE FROM casesvc.caseevent WHERE category_fk = 'COMMUNAL_ESTABLISHMENT_INSTITUTION';
 DELETE FROM casesvc.category WHERE category_pk = 'COMMUNAL_ESTABLISHMENT_INSTITUTION';
+
+DELETE FROM casesvc.caseevent WHERE category_fk = 'DECEASED';
 DELETE FROM casesvc.category WHERE category_pk = 'DECEASED';
+
+DELETE FROM casesvc.caseevent WHERE category_fk = 'DWELLING_OF_FOREIGN_SERVICE_PERSONNEL_DIPLOMATS';
 DELETE FROM casesvc.category WHERE category_pk = 'DWELLING_OF_FOREIGN_SERVICE_PERSONNEL_DIPLOMATS';
+
+DELETE FROM casesvc.caseevent WHERE category_fk = 'FULL_INTERVIEW_REQUEST_DATA_DELETED';
 DELETE FROM casesvc.category WHERE category_pk = 'FULL_INTERVIEW_REQUEST_DATA_DELETED';
+
+DELETE FROM casesvc.caseevent WHERE category_fk = 'FULL_INTERVIEW_REQUEST_DATA_DELETED_INCORRECT';
 DELETE FROM casesvc.category WHERE category_pk = 'FULL_INTERVIEW_REQUEST_DATA_DELETED_INCORRECT';
+
+DELETE FROM casesvc.caseevent WHERE category_fk = 'ILL_AT_HOME';
 DELETE FROM casesvc.category WHERE category_pk = 'ILL_AT_HOME';
+
+DELETE FROM casesvc.caseevent WHERE category_fk = 'IN_HOSPITAL';
 DELETE FROM casesvc.category WHERE category_pk = 'IN_HOSPITAL';
+
+DELETE FROM casesvc.caseevent WHERE category_fk = 'LEGITIMACY_CONCERNS';
 DELETE FROM casesvc.category WHERE category_pk = 'LEGITIMACY_CONCERNS';
+
+DELETE FROM casesvc.caseevent WHERE category_fk = 'NO_PERSON_IN_ELIGIBLE_AGE_RANGE';
 DELETE FROM casesvc.category WHERE category_pk = 'NO_PERSON_IN_ELIGIBLE_AGE_RANGE';
+
+DELETE FROM casesvc.caseevent WHERE category_fk = 'NO_TRACE_OF_ADDRESS';
 DELETE FROM casesvc.category WHERE category_pk = 'NO_TRACE_OF_ADDRESS';
+
+DELETE FROM casesvc.caseevent WHERE category_fk = 'OTHER_CIRCUMSTANTIAL_REFUSAL';
 DELETE FROM casesvc.category WHERE category_pk = 'OTHER_CIRCUMSTANTIAL_REFUSAL';
+
+DELETE FROM casesvc.caseevent WHERE category_fk = 'OTHER_OUTRIGHT_REFUSAL';
 DELETE FROM casesvc.category WHERE category_pk = 'OTHER_OUTRIGHT_REFUSAL';
+
+DELETE FROM casesvc.caseevent WHERE category_fk = 'PARTIAL_INTERVIEW_REQUEST_DATA_DELETED';
 DELETE FROM casesvc.category WHERE category_pk = 'PARTIAL_INTERVIEW_REQUEST_DATA_DELETED';
+
+DELETE FROM casesvc.caseevent WHERE category_fk = 'PARTIAL_INTERVIEW_REQUEST_DATA_DELETED_INCORRECT';
 DELETE FROM casesvc.category WHERE category_pk = 'PARTIAL_INTERVIEW_REQUEST_DATA_DELETED_INCORRECT';
+
+DELETE FROM casesvc.caseevent WHERE category_fk = 'REQUEST_TO_COMPLETE_IN_ALTERNATIVE_FORMAT';
 DELETE FROM casesvc.category WHERE category_pk = 'REQUEST_TO_COMPLETE_IN_ALTERNATIVE_FORMAT';
+
+DELETE FROM casesvc.caseevent WHERE category_fk = 'VACANT_OR_EMPTY';
 DELETE FROM casesvc.category WHERE category_pk = 'VACANT_OR_EMPTY';
+
+DELETE FROM casesvc.caseevent WHERE category_fk = 'WRONG_ADDRESS';
 DELETE FROM casesvc.category WHERE category_pk = 'WRONG_ADDRESS';


### PR DESCRIPTION
# What and why?

The original SQL didn't account for records that depended on those categories.  Because these statuses aren't used in the current system, and the records that are there are for social cases that the current system no longer supports, we can delete them without worry

# How to test?

# Trello
