### PR TITLE
Add endpoint for all cases

### DIFF
--- a/_infra/helm/case/Chart.yaml
+++ b/_infra/helm/case/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 11.2.0
+version: 11.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 11.2.0
+appVersion: 11.2.1

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -171,6 +171,62 @@ paths:
         404:
           description: Not Found
           content: {}
+  /casegroups/cases/{collectionExerciseId}:
+    get:
+      tags:
+        - case-group-endpoint
+      summary: findCaseGroupsByCollectionExerciseId
+      operationId: findCaseGroupsByCollectionExerciseIddUsingGET
+      description: returns a count of casegroups with a given collection exercise id in the NOT_STARTED and IN_PROGRESS state
+      parameters:
+        - name: collectionExerciseId
+          in: path
+          description: the uuid of the collection exercise
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: OK
+          content:
+            text/plain:
+              schema:
+                type: number
+                example: 10503
+        401:
+          description: Unauthorized
+          content: { }
+        403:
+          description: Forbidden
+          content: { }
+  /casegroups/cases/{collectionExerciseId}/all:
+    get:
+      tags:
+        - case-group-endpoint
+      summary: findCaseGroupsByCollectionExerciseId
+      operationId: findCaseGroupsByCollectionExerciseIdUsingGET
+      description: returns a count of casegroups with a given collection exercise id
+      parameters:
+        - name: collectionExerciseId
+          in: path
+          description: the uuid of the collection exercise
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: OK
+          content:
+            text/plain:
+              schema:
+                type: number
+                example: 10503
+        401:
+          description: Unauthorized
+          content: { }
+        403:
+          description: Forbidden
+          content: { }
   /cases/casegroupid/{casegroupId}:
     get:
       tags:

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/domain/repository/CaseGroupRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/domain/repository/CaseGroupRepository.java
@@ -50,6 +50,8 @@ public interface CaseGroupRepository extends JpaRepository<CaseGroup, Integer> {
   CaseGroup findCaseGroupByCollectionExerciseIdAndSampleUnitRef(
       UUID collectionExerciseId, String ruRef);
 
+  Long countCaseGroupByCollectionExerciseId(UUID collectionExerciseId);
+
   @Query(
       "SELECT count (*) FROM CaseGroup cg, Case c "
           + "WHERE c.caseGroupFK=cg.caseGroupPK "

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseGroupEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseGroupEndpoint.java
@@ -85,6 +85,19 @@ public final class CaseGroupEndpoint implements CTPEndpoint {
     return ResponseEntity.ok(numberOfCases);
   }
 
+  @RequestMapping(value = "/cases/{collectionExerciseId}/all", method = RequestMethod.GET)
+  public ResponseEntity findAllCasesForCollectionExercise(
+      @PathVariable("collectionExerciseId") final UUID collectionExerciseId) throws CTPException {
+    // TODO: This endpoint needs to be combined with findNumberOfCases and given a sensible
+    // implementation.
+    // This is being added now to fix a production issue quickly.
+    log.with("collectionExerciseId", collectionExerciseId)
+        .debug("Finding all cases against collectionExercise");
+    Long numberOfCases =
+        caseGroupService.getAllCasesAgainstCollectionExerciseId(collectionExerciseId);
+    return ResponseEntity.ok(numberOfCases);
+  }
+
   /**
    * the GET endpoint to find CaseGroups by partyid UUID
    *

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/CaseGroupService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/CaseGroupService.java
@@ -176,4 +176,15 @@ public class CaseGroupService {
     }
     return numberOfCases;
   }
+
+  public Long getAllCasesAgainstCollectionExerciseId(UUID collectionExerciseId)
+      throws CTPException {
+    Long numberOfCases = caseGroupRepo.countCaseGroupByCollectionExerciseId(collectionExerciseId);
+    if (numberOfCases == null) {
+      throw new CTPException(
+          CTPException.Fault.RESOURCE_NOT_FOUND,
+          String.format("Cannot find cases against collection exercise %s", collectionExerciseId));
+    }
+    return numberOfCases;
+  }
 }


### PR DESCRIPTION
# What and why?

The endpoint that gives casegroups for a given collection exercise id will only give you the ones in IN_PROGRESS and NOT_STARTED.  Collection exercise needed one where it would return them all regardless of state.  This PR adds that endpoint.

# How to test?

# Trello
