### PR TITLE
Renaming completed to processed status enum to match the previous data

### DIFF
--- a/_infra/helm/case/Chart.yaml
+++ b/_infra/helm/case/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 11.2.18
+version: 11.2.19
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 11.2.18
+appVersion: 11.2.19

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/domain/model/CaseActionEventRequest.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/domain/model/CaseActionEventRequest.java
@@ -24,7 +24,8 @@ public class CaseActionEventRequest implements Serializable {
     INPROGRESS,
     COMPLETED,
     FAILED,
-    RETRY
+    RETRY,
+    PROCESSED
   }
 
   @Id

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/action/ProcessCaseActionEventService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/action/ProcessCaseActionEventService.java
@@ -119,7 +119,11 @@ public class ProcessCaseActionEventService {
   private void updateCollectionExerciseEventStatus(
       CaseActionEventRequest request, CaseActionEvent event) throws JsonProcessingException {
     CaseActionEvent caseActionEvent = (null != event) ? event : new CaseActionEvent();
-    caseActionEvent.setStatus(request.getStatus());
+    ActionEventRequestStatus status =
+        request.getStatus().equals(ActionEventRequestStatus.COMPLETED)
+            ? ActionEventRequestStatus.PROCESSED
+            : request.getStatus();
+    caseActionEvent.setStatus(status);
     if (event == null) {
       caseActionEvent.setCollectionExerciseID(request.getCollectionExerciseId());
       caseActionEvent.setTag(CaseActionEvent.EventTag.valueOf(request.getEventTag()));

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseActionEventIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/endpoint/CaseActionEventIT.java
@@ -149,7 +149,7 @@ public class CaseActionEventIT {
         caseActionEventRequestList.get(0).getStatus());
     CaseActionEvent eventStatus = message.getPubSubCaseActionEventStatus();
     Assert.assertEquals(
-        CaseActionEventRequest.ActionEventRequestStatus.COMPLETED, eventStatus.getStatus());
+        CaseActionEventRequest.ActionEventRequestStatus.PROCESSED, eventStatus.getStatus());
   }
 
   @Test
@@ -188,7 +188,7 @@ public class CaseActionEventIT {
         caseActionEventRequestList.get(0).getStatus());
     CaseActionEvent eventStatus = message.getPubSubCaseActionEventStatus();
     Assert.assertEquals(
-        CaseActionEventRequest.ActionEventRequestStatus.COMPLETED, eventStatus.getStatus());
+        CaseActionEventRequest.ActionEventRequestStatus.PROCESSED, eventStatus.getStatus());
   }
 
   @Test


### PR DESCRIPTION
# What and why?

# How to test?

# Trello
https://trello.com/c/9H8g3qTR/1131-bug-status-change-merge-failing-in-preprod