### PR TITLE
Use latest collection exercise version in case integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,6 @@ Suggested improvements can be found here:
 [Improvements](IMPROVEMENTS.md)
 
 ## Running
-
-There are two ways of running this service
-
 * Run
     ```bash
     cp .maven.settings.xml ~/.m2/settings.xml  # This only needs to be done once to set up mavens settings file

--- a/README.md
+++ b/README.md
@@ -111,19 +111,25 @@ Suggested improvements can be found here:
 
 There are two ways of running this service
 
-* The easiest way is via docker (https://github.com/ONSdigital/ras-rm-docker-dev)
-* Alternatively running the service up in isolation
+* Run
     ```bash
     cp .maven.settings.xml ~/.m2/settings.xml  # This only needs to be done once to set up mavens settings file
     mvn clean install
     mvn spring-boot:run
     ```
+  
 
 # Code Styler
 To use the code styler please goto this url (https://github.com/google/google-java-format) and follow the Intellij instructions or Eclipse depending on what you use
 
 ## API
 Open API spec can be found [here](API.yaml)
+
+## Integration tests
+Use the command 'mvn clean install' this will run the tests in docker.
+
+Note: You may need to a service account and key can be found locally in your environment and use the command 
+"export GOOGLE_APPLICATION_CREDENTIALS='/[PATH]/[NAME_OF_KEY].json'" (remove the double quotes)
 
 ## To test
 See curlTests.txt under /test/resources

--- a/README.md
+++ b/README.md
@@ -114,7 +114,6 @@ Suggested improvements can be found here:
     mvn clean install
     mvn spring-boot:run
     ```
-  
 
 # Code Styler
 To use the code styler please goto this url (https://github.com/google/google-java-format) and follow the Intellij instructions or Eclipse depending on what you use

--- a/_infra/helm/case/Chart.yaml
+++ b/_infra/helm/case/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 11.2.28
+version: 11.2.29
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 11.2.28
+appVersion: 11.2.29

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     external_links:
       - postgres-case-it
       - redis-case-it
-    image: eu.gcr.io/ons-rasrmbs-management/collection-exercise:11.1.8
+    image: eu.gcr.io/ons-rasrmbs-management/collection-exercise:latest
     environment:
       - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres-case-it:5432/postgres?sslmode=disable
       - SPRING_DATASOURCE_USERNAME=postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,6 @@ services:
     container_name: collex-case-it
     external_links:
       - postgres-case-it
-      - redis-case-it
     image: eu.gcr.io/ons-rasrmbs-management/collection-exercise:latest
     environment:
       - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres-case-it:5432/postgres?sslmode=disable
@@ -15,8 +14,6 @@ services:
       - SPRING_LIQUIBASE_PASSWORD=postgres
       - SPRING_CLOUD_GCP_PROJECTID=test
       - SPRING_CLOUD_GCP_PUBSUB_EMULATORHOST:pubsub-emulator-it:8681
-      - REDISSON_CONFIG_ADDRESS=redis-case-it:6379
-      - DATA_GRID_ADDRESS=redis-case-it:6379
       - SURVEY_SVC_CONNECTION_CONFIG_HOST=survey-case-it
       - SURVEY_SVC_CONNECTION_CONFIG_PORT=8080
       - PUBSUB_EMULATOR_HOST=pubsub-emulator-it:8681
@@ -32,12 +29,6 @@ services:
       - POSTGRES_DB=postgres
     ports:
     - "15432:5432"
-  # redis is used for collection exercise and not for case service
-  redis:
-    container_name: redis-case-it
-    image: redis:3.2.9
-    ports:
-    - "17379:6379"
 
   pubsub-emulator:
     container_name: pubsub-emulator-it

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,10 +13,11 @@ services:
       - SPRING_LIQUIBASE_USER=postgres
       - SPRING_LIQUIBASE_PASSWORD=postgres
       - SPRING_CLOUD_GCP_PROJECTID=test
-      - SPRING_CLOUD_GCP_PUBSUB_EMULATORHOST:pubsub-emulator-it:8681
+      - SPRING_CLOUD_GCP_PUBSUB_EMULATORHOST=pubsub-emulator-it:8681
       - SURVEY_SVC_CONNECTION_CONFIG_HOST=survey-case-it
       - SURVEY_SVC_CONNECTION_CONFIG_PORT=8080
       - PUBSUB_EMULATOR_HOST=pubsub-emulator-it:8681
+
     ports:
       - "38145:8145"
 

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -58,7 +58,7 @@ internet-access-code-svc:
 collection-exercise-svc:
   connection-config:
     scheme: http
-    host: localhost
+    host: collectionexercise
     port: 8145
     username: admin
     password: secret

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -23,12 +23,6 @@ survey-svc:
     password: secret
     retry-attempts: 5
 
-redisson-config:
-  address: localhost:17379
-
-data-grid:
-  address: localhost:17379
-
 case-distribution:
   retrieval-max: 50
   delay-milli-seconds: 500
@@ -57,9 +51,7 @@ internet-access-code-svc:
 
 collection-exercise-svc:
   connection-config:
-    scheme: http
-    host: collectionexercise
-    port: 8145
+    port: 38145
     username: admin
     password: secret
 

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -57,7 +57,7 @@ internet-access-code-svc:
 
 collection-exercise-svc:
   connection-config:
-    port: 38145
+    port: 8145
     username: admin
     password: secret
 

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -57,7 +57,9 @@ internet-access-code-svc:
 
 collection-exercise-svc:
   connection-config:
-    port: 38145
+    scheme: http
+    host: localhost
+    port: 8145
     username: admin
     password: secret
 

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -57,7 +57,7 @@ internet-access-code-svc:
 
 collection-exercise-svc:
   connection-config:
-    port: 8145
+    port: 38145
     username: admin
     password: secret
 


### PR DESCRIPTION
# What and why?
The docker-compose was incorrectly sending through the  'SPRING_CLOUD_GCP_PUBSUB_EMULATORHOST' environment variable. It was using ':' instead of '='. This has been fixed now.

Redundant references to Redis in the docker-compose.yml have been removed.

I have also updated the readme as this was out of date. 

# How to test?
Run the command 'mvn clean install'. This will spin up docker and run the integration tests.

# Trello
https://trello.com/c/3UuEbzPf/1793-use-latest-collection-exercise-version-in-case-integration-tests
