### PR TITLE
RAS-675: Extend surveyIdSupportedTemplate to support UKIS

### DIFF
--- a/_infra/helm/case/Chart.yaml
+++ b/_infra/helm/case/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 12.0.5
+version: 12.0.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 12.0.5
+appVersion: 12.0.6

--- a/_infra/helm/case/values.yaml
+++ b/_infra/helm/case/values.yaml
@@ -89,4 +89,4 @@ crons:
 surveySvc:
   multipleFormTypeSupportedSurveyIds: "202"
   multipleFormTypeSupported: "1862,1864,1874"
-  surveyIdSupportedTemplate: "024,283"
+  surveyIdSupportedTemplate: "024,283,144"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -121,7 +121,7 @@ survey-svc:
     read-timeout-milli-seconds: 5000
   multiple-form-type-supported-survey-ids: "202,203"
   multiple-form-type-supported: "1862,1864,1874"
-  survey-id-supported-template: "024,283"
+  survey-id-supported-template: "024,283,144"
 
 case-distribution:
   retrieval-max: 50


### PR DESCRIPTION
# What and why?
UKIS needs to use its own template when being used in notify email.

# How to test?
Deploy code to your dev environment, then add a UKIS, survey ID 144 to rOps, add a CE and make it go live. Goto the logs of case service in GCP and see that there is a log with 'sending email data to pubsub' and the case id with it. There should also be a template of 'BSNE' (for notifications) or 'BSRE' (for reminders). 

# JIRA
https://jira.ons.gov.uk/browse/RAS-675
