### PR TITLE
RAS-720 update Cronjob to v1

### DIFF
--- a/_infra/helm/case/templates/retry-failed-event.yaml
+++ b/_infra/helm/case/templates/retry-failed-event.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ .Values.crons.retryEventScheduler.name }}


### PR DESCRIPTION
# What and why?
This PR updates the CronJob version from v1beta to v1
# How to test?
Deploying to case via helm, ```helm install case ./_infra/helm/case``` The change from v1beta to v1 was tested here asw well https://github.com/ONSdigital/ras-party/pull/390
# Trello
