### PR TITLE
updated jackson

### DIFF
--- a/_infra/helm/case/Chart.yaml
+++ b/_infra/helm/case/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 12.0.8
+version: 12.0.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 12.0.8
+appVersion: 12.0.9

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <springboot.version>2.6.6</springboot.version>
         <common.version>10.49.4</common.version>
-        <jackson.version>2.13.4.2</jackson.version>
+        <jackson.version>2.13.5</jackson.version>
         <java.version>17</java.version>
         <surefire.version>2.20</surefire.version>
         <godaddylogging.version>1.2.5</godaddylogging.version>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <springboot.version>2.6.6</springboot.version>
         <common.version>10.49.4</common.version>
-        <jackson.version>2.13.3</jackson.version>
+        <jackson.version>2.13.4.2</jackson.version>
         <java.version>17</java.version>
         <surefire.version>2.20</surefire.version>
         <godaddylogging.version>1.2.5</godaddylogging.version>


### PR DESCRIPTION
# What and why?
Dependabot highlighted a security vulnerability that required jackson-databind be updated to at least version 2.13.4.2.

# How to test?
Deploy and run acceptance test.

# Jira
[Card](https://jira.ons.gov.uk/browse/RAS-792)
