### PR TITLE
RAS-872: Extend EQ launch claims to include sds_dataset_id if required for the form_type

### DIFF
--- a/_infra/helm/case/Chart.yaml
+++ b/_infra/helm/case/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 12.0.12
+version: 12.0.13
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 12.0.12
+appVersion: 12.0.13

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/message/feedback/CaseReceipt.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/message/feedback/CaseReceipt.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.ctp.response.casesvc.message.feedback;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -15,4 +16,7 @@ public class CaseReceipt {
   private String caseId;
   private InboundChannel inboundChannel;
   private String partyId;
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private String sdsDatasetId;
 }


### PR DESCRIPTION
# What and why?
The SDS ID is required to be passed to eQ when an SDS is present and the form type(s) in question match that supplied by SDS. This PR achieves this by updating the receipting object to include the SDS id'

# How to test?
Refer to frontstage PR.

# Jira
https://jira.ons.gov.uk/browse/RAS-872