### PR TITLE
rename NOT_ENGLAND variable to NI_REGION_CODE 

### DIFF
--- a/_infra/helm/case/Chart.yaml
+++ b/_infra/helm/case/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 12.0.13
+version: 12.0.14
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 12.0.13
+appVersion: 12.0.14

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/representation/action/NotifyModel.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/representation/action/NotifyModel.java
@@ -98,7 +98,7 @@ public class NotifyModel {
         private static final String REMINDER = "REMINDER";
         private static final String NOTIFICATION = "NOTIFICATION";
         // a region of YY appears to be any region that isnt england
-        private static final String NOT_ENGLAND = "YY";
+        private static final String NI_REGION_CODE = "YY";
 
         private String actionType;
         private String legalBasis;
@@ -115,8 +115,8 @@ public class NotifyModel {
             return new Classifiers(actionType, "", "", "", "");
           }
 
-          // if not not england is england. welcome to ras-rm.
-          if (!NOT_ENGLAND.equals(region)) {
+          // if NOT NI then England
+          if (!NI_REGION_CODE.equals(region)) {
             region = "";
           }
 

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/representation/action/NotifyModel.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/representation/action/NotifyModel.java
@@ -115,7 +115,7 @@ public class NotifyModel {
             return new Classifiers(actionType, "", "", "", "");
           }
 
-          // if NOT NI then England
+          // if NOT NI then England/Wales
           if (!NI_REGION_CODE.equals(region)) {
             region = "";
           }


### PR DESCRIPTION
# What and why?
Fix a bit of confusion around the following bit of code 

{{ // if not not england is england. welcome to ras-rm.
if (!NOT_ENGLAND.equals(region)) {
region = "";
}}}

rename NOT_ENGLAND so it can make more sense

# How to test?

# Jira

https://jira.ons.gov.uk/browse/RAS-769
