### PR TITLE
Migrate from openjdk to eclipse-temurin

### DIFF
--- a/_infra/docker/Dockerfile
+++ b/_infra/docker/Dockerfile
@@ -1,11 +1,9 @@
-FROM openjdk:17-slim
+FROM eclipse-temurin:17-jre-alpine
 
 ARG JAR_FILE=case.jar
-RUN apt-get update
 
 ENV JAVA_OPTS=""
 
 COPY target/$JAR_FILE /opt/$JAR_FILE
 
 ENTRYPOINT [ "sh", "-c", "java $JAVA_OPTS -jar /opt/case.jar" ]
-


### PR DESCRIPTION
# What and why?

The openjdk base images are deprecated and no longer maintained. This migrates to the recommended [eclipse-temurin](https://hub.docker.com/_/eclipse-temurin) image. This also migrates from the slim Linux OS to the alpine OS images as eclipse-temurin doesn't appear to offer slim. This reduces the image from ~305BM to ~143MB

# How to test

Does the image build, does the application start, and do the acceptance tests pass?
