### PR TITLE
Update Mockito-inline to Mockito-core

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Authenticate with Google Cloud
         id: auth
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCR_KEY }}
       - name: Setup Google Cloud SDK

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Authenticate with Google Cloud
         id: auth
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCR_KEY }}
       - name: Setup Google Cloud SDK

--- a/pom.xml
+++ b/pom.xml
@@ -274,9 +274,14 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <version>4.6.1</version>
+            <artifactId>mockito-core</artifactId>
+            <version>5.5.0</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+            <version>1.14.8</version>
         </dependency>
         <dependency>
             <groupId>javax.xml.ws</groupId>


### PR DESCRIPTION
# What and why?
This PR updates mockito-inline to mockito-core and adds the required byte-buddy dependency.

GHA auth deprecation has also been addressed in this PR. 

# How to test?
- Run local tests 
- Deploy and run acceptance tests
- 
# Jira
https://jira.ons.gov.uk/secure/RapidBoard.jspa?rapidView=1493&view=detail&selectedIssue=RAS-949