### PR TITLE
RAS-940: Questionnaire Completion Rate Information

### DIFF
--- a/_infra/helm/case/Chart.yaml
+++ b/_infra/helm/case/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 12.0.18
+version: 12.0.19
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 12.0.18
+appVersion: 12.0.19

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/domain/model/CaseGroup.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/domain/model/CaseGroup.java
@@ -63,6 +63,6 @@ public class CaseGroup implements Serializable {
   @Column(name = "status")
   private CaseGroupStatus status;
 
-  @Column(name = "change_state_timestamp")
-  private Timestamp changeStateTimestamp;
+  @Column(name = "status_change_timestamp")
+  private Timestamp statusChangeTimestamp;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/domain/model/CaseGroup.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/domain/model/CaseGroup.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.ctp.response.casesvc.domain.model;
 
 import java.io.Serializable;
+import java.sql.Timestamp;
 import java.util.UUID;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -61,4 +62,7 @@ public class CaseGroup implements Serializable {
   @Enumerated(EnumType.STRING)
   @Column(name = "status")
   private CaseGroupStatus status;
+
+  @Column(name = "change_state_timestamp")
+  private Timestamp changeStateTimestamp;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/CaseGroupAuditService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/CaseGroupAuditService.java
@@ -22,7 +22,7 @@ public class CaseGroupAuditService {
     auditEntity.setCaseGroupFK(caseGroup.getCaseGroupPK());
     auditEntity.setStatus(caseGroup.getStatus());
     auditEntity.setPartyId(partyId);
-    auditEntity.setCreatedDateTime(caseGroup.getChangeStateTimestamp());
+    auditEntity.setCreatedDateTime(caseGroup.getStatusChangeTimestamp());
     log.with("audit_entity", auditEntity).debug("Updating the caseGroupStatus");
     caseGroupStatusAuditRepository.saveAndFlush(auditEntity);
   }

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/CaseGroupAuditService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/CaseGroupAuditService.java
@@ -8,7 +8,6 @@ import org.springframework.stereotype.Service;
 import uk.gov.ons.ctp.response.casesvc.domain.model.CaseGroup;
 import uk.gov.ons.ctp.response.casesvc.domain.model.CaseGroupStatusAudit;
 import uk.gov.ons.ctp.response.casesvc.domain.repository.CaseGroupStatusAuditRepository;
-import uk.gov.ons.ctp.response.lib.common.time.DateTimeUtil;
 
 @Service
 public class CaseGroupAuditService {
@@ -23,7 +22,7 @@ public class CaseGroupAuditService {
     auditEntity.setCaseGroupFK(caseGroup.getCaseGroupPK());
     auditEntity.setStatus(caseGroup.getStatus());
     auditEntity.setPartyId(partyId);
-    auditEntity.setCreatedDateTime(DateTimeUtil.nowUTC());
+    auditEntity.setCreatedDateTime(caseGroup.getChangeStateTimestamp());
     log.with("audit_entity", auditEntity).debug("Updating the caseGroupStatus");
     caseGroupStatusAuditRepository.saveAndFlush(auditEntity);
   }

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/CaseGroupService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/CaseGroupService.java
@@ -107,7 +107,7 @@ public class CaseGroupService {
 
     if (newCaseGroupStatus != null && !oldCaseGroupStatus.equals(newCaseGroupStatus)) {
       caseGroup.setStatus(newCaseGroupStatus);
-      caseGroup.setChangeStateTimestamp(DateTimeUtil.nowUTC());
+      caseGroup.setStatusChangeTimestamp(DateTimeUtil.nowUTC());
       caseGroupRepo.saveAndFlush(caseGroup);
       caseGroupAuditService.updateAuditTable(caseGroup, partyId);
     }

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/CaseGroupService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/CaseGroupService.java
@@ -18,6 +18,7 @@ import uk.gov.ons.ctp.response.casesvc.representation.CategoryDTO;
 import uk.gov.ons.ctp.response.lib.collection.exercise.CollectionExerciseDTO;
 import uk.gov.ons.ctp.response.lib.common.error.CTPException;
 import uk.gov.ons.ctp.response.lib.common.state.StateTransitionManager;
+import uk.gov.ons.ctp.response.lib.common.time.DateTimeUtil;
 
 /**
  * A CaseGroupService implementation which encapsulates all business logic operating on the
@@ -106,6 +107,7 @@ public class CaseGroupService {
 
     if (newCaseGroupStatus != null && !oldCaseGroupStatus.equals(newCaseGroupStatus)) {
       caseGroup.setStatus(newCaseGroupStatus);
+      caseGroup.setChangeStateTimestamp(DateTimeUtil.nowUTC());
       caseGroupRepo.saveAndFlush(caseGroup);
       caseGroupAuditService.updateAuditTable(caseGroup, partyId);
     }

--- a/src/main/resources/database/changelog-master.yml
+++ b/src/main/resources/database/changelog-master.yml
@@ -142,3 +142,6 @@ databaseChangeLog:
 
   - include:
       file: database/changes/release-35/changelog.yml
+
+  - include:
+      file: database/changes/release-36/changelog.yml

--- a/src/main/resources/database/changes/release-36/add_timestamp_for_status_change.sql
+++ b/src/main/resources/database/changes/release-36/add_timestamp_for_status_change.sql
@@ -1,0 +1,2 @@
+ALTER TABLE ONLY casesvc.casegroup
+    ADD change_state_timestamp timestamp with time zone;

--- a/src/main/resources/database/changes/release-36/add_timestamp_for_status_change.sql
+++ b/src/main/resources/database/changes/release-36/add_timestamp_for_status_change.sql
@@ -1,2 +1,2 @@
 ALTER TABLE ONLY casesvc.casegroup
-    ADD change_state_timestamp timestamp with time zone;
+    ADD status_change_timestamp timestamp with time zone;

--- a/src/main/resources/database/changes/release-36/changelog.yml
+++ b/src/main/resources/database/changes/release-36/changelog.yml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+
+  - changeSet:
+      id: 36-1
+      author: Steve Scorfield
+      changes:
+        - sqlFile:
+            comment: Add a timestamp column for when a status change is made to the survey for a respondent
+            path: add_timestamp_for_status_change.sql
+            relativeToChangelogFile: true
+            splitStatements: false

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/service/CaseGroupServiceTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/service/CaseGroupServiceTest.java
@@ -6,7 +6,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 import java.util.*;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -43,7 +42,7 @@ public class CaseGroupServiceTest {
   private static final UUID SURVEY_ID = UUID.fromString("cb8accda-6118-4d3b-85a3-149e28960c54");
 
   @Test
-  public void givenCaseGroupStatusWhenCaseGroupStatusTransitionedThenTransitionIsSaved()
+  public void testCaseGroupCorrectlyTransitionsToNewStatus()
       throws Exception {
     // Given
     CaseGroup caseGroup =
@@ -65,13 +64,13 @@ public class CaseGroupServiceTest {
     caseGroupService.transitionCaseGroupStatus(caseGroup, categoryName, caseGroup.getPartyId());
 
     // Then
-    Assert.assertNotNull(caseGroup.getStatusChangeTimestamp());
-    Assert.assertEquals(caseGroup.getStatus(), CaseGroupStatus.COMPLETE);
+    assertNotNull(caseGroup.getStatusChangeTimestamp());
+    assertEquals(caseGroup.getStatus(), CaseGroupStatus.COMPLETE);
     verify(caseGroupRepo).saveAndFlush(caseGroup);
   }
 
   @Test
-  public void givenCaseGroupStatusWhenCaseGroupStatusTransitionedThenTransitionIsAudited()
+  public void testCaseGroupStatusChangeIsCorrectlyAudited()
       throws Exception {
     // Given
     CaseGroup caseGroup =
@@ -93,7 +92,6 @@ public class CaseGroupServiceTest {
     caseGroupService.transitionCaseGroupStatus(caseGroup, categoryName, caseGroup.getPartyId());
 
     // Then
-
     verify(caseGroupAuditService).updateAuditTable(caseGroup, caseGroup.getPartyId());
   }
 

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/service/CaseGroupServiceTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/service/CaseGroupServiceTest.java
@@ -65,6 +65,8 @@ public class CaseGroupServiceTest {
     caseGroupService.transitionCaseGroupStatus(caseGroup, categoryName, caseGroup.getPartyId());
 
     // Then
+    Assert.assertNotNull(caseGroup.getStatusChangeTimestamp());
+    Assert.assertEquals(caseGroup.getStatus(), CaseGroupStatus.COMPLETE);
     verify(caseGroupRepo).saveAndFlush(caseGroup);
   }
 
@@ -91,6 +93,7 @@ public class CaseGroupServiceTest {
     caseGroupService.transitionCaseGroupStatus(caseGroup, categoryName, caseGroup.getPartyId());
 
     // Then
+
     verify(caseGroupAuditService).updateAuditTable(caseGroup, caseGroup.getPartyId());
   }
 
@@ -295,32 +298,5 @@ public class CaseGroupServiceTest {
     caseGroupService.findCaseGroupsForExecutedCollectionExercises(null);
 
     // Then throws CTPException
-  }
-
-  @Test
-  public void
-      givenCaseGroupStatusWhenCaseGroupStatusTransitionedThenStatusChangeTimestampIsUpdated()
-          throws Exception {
-    // Given
-    CaseGroup caseGroup =
-        CaseGroup.builder()
-            .id(UUID.randomUUID())
-            .collectionExerciseId(UUID.randomUUID())
-            .partyId(UUID.randomUUID())
-            .sampleUnitRef("12345")
-            .sampleUnitType("B")
-            .status(CaseGroupStatus.NOTSTARTED)
-            .build();
-
-    CategoryDTO.CategoryName categoryName =
-        CategoryDTO.CategoryName.COLLECTION_INSTRUMENT_DOWNLOADED;
-    given(caseGroupStatusTransitionManager.transition(caseGroup.getStatus(), categoryName))
-        .willReturn(CaseGroupStatus.COMPLETE);
-
-    // When
-    caseGroupService.transitionCaseGroupStatus(caseGroup, categoryName, caseGroup.getPartyId());
-
-    // Then
-    Assert.assertNotNull(caseGroup.getStatusChangeTimestamp());
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/service/CaseGroupServiceTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/service/CaseGroupServiceTest.java
@@ -6,7 +6,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 import java.util.*;
-
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -299,23 +298,24 @@ public class CaseGroupServiceTest {
   }
 
   @Test
-  public void givenCaseGroupStatusWhenCaseGroupStatusTransitionedThenStatusChangeTimestampIsUpdated()
+  public void
+      givenCaseGroupStatusWhenCaseGroupStatusTransitionedThenStatusChangeTimestampIsUpdated()
           throws Exception {
     // Given
     CaseGroup caseGroup =
-            CaseGroup.builder()
-                    .id(UUID.randomUUID())
-                    .collectionExerciseId(UUID.randomUUID())
-                    .partyId(UUID.randomUUID())
-                    .sampleUnitRef("12345")
-                    .sampleUnitType("B")
-                    .status(CaseGroupStatus.NOTSTARTED)
-                    .build();
+        CaseGroup.builder()
+            .id(UUID.randomUUID())
+            .collectionExerciseId(UUID.randomUUID())
+            .partyId(UUID.randomUUID())
+            .sampleUnitRef("12345")
+            .sampleUnitType("B")
+            .status(CaseGroupStatus.NOTSTARTED)
+            .build();
 
     CategoryDTO.CategoryName categoryName =
-            CategoryDTO.CategoryName.COLLECTION_INSTRUMENT_DOWNLOADED;
+        CategoryDTO.CategoryName.COLLECTION_INSTRUMENT_DOWNLOADED;
     given(caseGroupStatusTransitionManager.transition(caseGroup.getStatus(), categoryName))
-            .willReturn(CaseGroupStatus.COMPLETE);
+        .willReturn(CaseGroupStatus.COMPLETE);
 
     // When
     caseGroupService.transitionCaseGroupStatus(caseGroup, categoryName, caseGroup.getPartyId());

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/service/CaseGroupServiceTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/service/CaseGroupServiceTest.java
@@ -6,6 +6,8 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 import java.util.*;
+
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -294,5 +296,31 @@ public class CaseGroupServiceTest {
     caseGroupService.findCaseGroupsForExecutedCollectionExercises(null);
 
     // Then throws CTPException
+  }
+
+  @Test
+  public void givenCaseGroupStatusWhenCaseGroupStatusTransitionedThenStatusChangeTimestampIsUpdated()
+          throws Exception {
+    // Given
+    CaseGroup caseGroup =
+            CaseGroup.builder()
+                    .id(UUID.randomUUID())
+                    .collectionExerciseId(UUID.randomUUID())
+                    .partyId(UUID.randomUUID())
+                    .sampleUnitRef("12345")
+                    .sampleUnitType("B")
+                    .status(CaseGroupStatus.NOTSTARTED)
+                    .build();
+
+    CategoryDTO.CategoryName categoryName =
+            CategoryDTO.CategoryName.COLLECTION_INSTRUMENT_DOWNLOADED;
+    given(caseGroupStatusTransitionManager.transition(caseGroup.getStatus(), categoryName))
+            .willReturn(CaseGroupStatus.COMPLETE);
+
+    // When
+    caseGroupService.transitionCaseGroupStatus(caseGroup, categoryName, caseGroup.getPartyId());
+
+    // Then
+    Assert.assertNotNull(caseGroup.getStatusChangeTimestamp());
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/service/CaseGroupServiceTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/service/CaseGroupServiceTest.java
@@ -42,8 +42,7 @@ public class CaseGroupServiceTest {
   private static final UUID SURVEY_ID = UUID.fromString("cb8accda-6118-4d3b-85a3-149e28960c54");
 
   @Test
-  public void testCaseGroupCorrectlyTransitionsToNewStatus()
-      throws Exception {
+  public void testCaseGroupCorrectlyTransitionsToNewStatus() throws Exception {
     // Given
     CaseGroup caseGroup =
         CaseGroup.builder()
@@ -70,8 +69,7 @@ public class CaseGroupServiceTest {
   }
 
   @Test
-  public void testCaseGroupStatusChangeIsCorrectlyAudited()
-      throws Exception {
+  public void testCaseGroupStatusChangeIsCorrectlyAudited() throws Exception {
     // Given
     CaseGroup caseGroup =
         CaseGroup.builder()


### PR DESCRIPTION
# What and why?
There is a requirement to add a datetime for when a respondents status is changed and to display this in the Response Chasing Report. This PR includes the code change to add the timedate to the Casegroup table.

# How to test?
Deploy this PR and update the status of a respondent (either via Frontstage or in rOps) and click the report for the associated survey. This will show the datetime of the status change within the Casegroup table.
Check the unit tests work and that the acceptance tests still work.
For completeness, deploy https://github.com/ONSdigital/rm-reporting/pull/110 and follow it's test instructions.

# Jira
https://jira.ons.gov.uk/browse/RAS-940