### PR TITLE
RAS-1238 Update to docker compose from docker-compose

### DIFF
--- a/_infra/helm/case/Chart.yaml
+++ b/_infra/helm/case/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 12.0.22
+version: 12.0.23
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 12.0.22
+appVersion: 12.0.23
 

--- a/docker-compose-down.sh
+++ b/docker-compose-down.sh
@@ -1,0 +1,1 @@
+docker compose down

--- a/docker-compose-up.sh
+++ b/docker-compose-up.sh
@@ -1,0 +1,1 @@
+docker compose up -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2.1'
 services:
   collectionexercise:
     container_name: collex-case-it

--- a/pom.xml
+++ b/pom.xml
@@ -217,12 +217,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.dkanejs.maven.plugins</groupId>
-            <artifactId>docker-compose-maven-plugin</artifactId>
-            <version>4.0.0</version>
-        </dependency>
-
-        <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
             <version>${jackson.version}</version>
@@ -322,6 +316,13 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/org.codehaus.mojo/exec-maven-plugin -->
+        <dependency>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <version>3.4.0</version>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -330,39 +331,40 @@
 
         <plugins>
             <plugin>
-                <groupId>com.dkanejs.maven.plugins</groupId>
-                <artifactId>docker-compose-maven-plugin</artifactId>
-                <version>4.0.0</version>
+                <artifactId>exec-maven-plugin</artifactId>
+                <groupId>org.codehaus.mojo</groupId>
                 <executions>
                     <execution>
                         <id>pre-stop</id>
                         <phase>pre-integration-test</phase>
                         <goals>
-                            <goal>down</goal>
+                            <goal>exec</goal>
                         </goals>
                         <configuration>
-                            <composeFile>${project.basedir}/docker-compose.yml</composeFile>
+                            <workingDirectory>${project.basedir}</workingDirectory>
+                            <executable>docker-compose-down.sh</executable>
                         </configuration>
                     </execution>
                     <execution>
                         <id>up</id>
                         <phase>pre-integration-test</phase>
                         <goals>
-                            <goal>up</goal>
+                            <goal>exec</goal>
                         </goals>
                         <configuration>
-                            <composeFile>${project.basedir}/docker-compose.yml</composeFile>
-                            <detachedMode>true</detachedMode>
+                            <workingDirectory>${project.basedir}</workingDirectory>
+                            <executable>docker-compose-up.sh</executable>
                         </configuration>
                     </execution>
                     <execution>
                         <id>down</id>
                         <phase>post-integration-test</phase>
                         <goals>
-                            <goal>down</goal>
+                            <goal>exec</goal>
                         </goals>
                         <configuration>
-                            <composeFile>${project.basedir}/docker-compose.yml</composeFile>
+                            <workingDirectory>${project.basedir}</workingDirectory>
+                            <executable>docker-compose-down.sh</executable>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
# What and why?
This PR replaces our use of the `docker-compose-maven-plugin` as that is still using `docker-compose` that has been removed
# How to test?
Check the build
# Jira
[RAS-1238](https://jira.ons.gov.uk/browse/RAS-1238)