### PR TITLE
Use migrated GAR pubsub-emulator image

### DIFF
--- a/_infra/helm/case/Chart.yaml
+++ b/_infra/helm/case/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 12.0.26
+version: 12.0.27
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 12.0.26
+appVersion: 12.0.27

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
 
   pubsub-emulator:
     container_name: pubsub-emulator-it
-    image: eu.gcr.io/ons-rasrmbs-management/pubsub-emulator
+    image: europe-west2-docker.pkg.dev/ons-ci-rmrasbs/images/pubsub-emulator
     ports:
     - "18681:8681"
     environment:


### PR DESCRIPTION
# What and why?

PubSub emulator has been migrated from GCR to GAR

# How to test?

Check the tests run in GHA and locally

# Jira

https://jira.ons.gov.uk/browse/RAS-1423