### PR TITLE
Adding graceful handling of duplicate case creation

### DIFF
--- a/_infra/helm/case/Chart.yaml
+++ b/_infra/helm/case/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 12.0.27
+version: 12.0.28
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 12.0.27
+appVersion: 12.0.28

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/service/CaseService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/service/CaseService.java
@@ -405,7 +405,7 @@ public class CaseService {
     }
   }
 
-  @Transactional
+  @Transactional(rollbackFor = Exception.class)
   public void createInitialCase(SampleUnitParent sampleUnitParent) throws CTPException {
     try {
       CaseGroup newCaseGroup = createNewCaseGroup(sampleUnitParent);
@@ -449,6 +449,7 @@ public class CaseService {
           .with("sampleUnitRef", sampleUnitParent.getSampleUnitRef())
           .with("error", exception)
           .warn("Case already exists. Ignoring case creation");
+      throw new CTPException(CTPException.Fault.DUPLICATE_RECORD, exception.getMessage());
     }
   }
 

--- a/src/main/java/uk/gov/ons/ctp/response/lib/common/error/CTPException.java
+++ b/src/main/java/uk/gov/ons/ctp/response/lib/common/error/CTPException.java
@@ -35,7 +35,9 @@ public class CTPException extends Exception {
     /** For access denied */
     ACCESS_DENIED,
     /** For bad requests */
-    BAD_REQUEST;
+    BAD_REQUEST,
+    /** Duplicate Record * */
+    DUPLICATE_RECORD
   }
 
   private Fault fault;

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/service/CaseCreationServiceTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/service/CaseCreationServiceTest.java
@@ -32,6 +32,7 @@ import uk.gov.ons.ctp.response.casesvc.representation.CaseGroupStatus;
 import uk.gov.ons.ctp.response.casesvc.representation.CaseState;
 import uk.gov.ons.ctp.response.lib.collection.exercise.CollectionExerciseDTO;
 import uk.gov.ons.ctp.response.lib.common.FixtureHelper;
+import uk.gov.ons.ctp.response.lib.common.error.CTPException;
 import uk.gov.ons.ctp.response.lib.common.state.StateTransitionManager;
 import uk.gov.ons.ctp.response.lib.sample.SampleUnitDTO;
 
@@ -202,7 +203,7 @@ public class CaseCreationServiceTest {
    * Create a Case and a Casegroup from the message that would be on the Case Delivery Queue. Child
    * party present.
    */
-  @Test
+  @Test(expected = CTPException.class)
   public void testCreateCaseAndCaseGroupDoesNothingIfDuplicate() throws Exception {
 
     SampleUnit sampleUnitChild = new SampleUnit();
@@ -237,6 +238,7 @@ public class CaseCreationServiceTest {
     caseService.createInitialCase(sampleUnitParent);
 
     // then nothing should be saved
+
     verify(caseGroupRepo, times(1)).saveAndFlush(any(CaseGroup.class));
     verify(caseRepo, times(0)).saveAndFlush(any(Case.class));
   }

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/service/CaseServiceTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/service/CaseServiceTest.java
@@ -903,7 +903,7 @@ public class CaseServiceTest {
     verify(caseRepo, times(6)).saveAndFlush(any());
   }
 
-  @Test
+  @Test(expected = CTPException.class)
   public void testCreateInitialCaseWithSampleUnitChildrenDoesNothingIfDuplicate() throws Exception {
     String collectionExerciseId = UUID.randomUUID().toString();
     UUID partyId = UUID.randomUUID();


### PR DESCRIPTION
# What and why?

For samples over a certain size, we periodically observe case creation messages being redelivered during setting ready for live. This appears to be due to the case service not being able to process a single message quickly enough, and the redelivery for unacknowledged messages happens while cases are being created.

This results in cases in the database, and then subsequent requests for the same case, causing constraint violations, which themselves result in no ack and redelivery of the same message multiple times until deadline.

Compounding this is the Spring error exception around unexpected rollback (within a nested transaction), that buries the underlying Postgres constraint violation being raised.

The safety net being introduced by this PR means we don't simply throw the Spring rollback exception, but now handle the constraint violation, raise our own new `DUPLICATE_RECORD` CTPException and ack the message. This is safe as the only reason the message exists is to create the record. While not ideal, the issue is not exceptional and we can recover from it by acking the message.

We should also try this change in combination with the ack deadline extension now we're not throwing the Spring rollback exception and nacking the message. However, that deadline is arbitrary and dependent on the performance of the case service to handle lots of messages at once so again it isn't the right solution. The right solution is a complete redesign of the case request handler.

# How to test?

Load a large sample and check messages get replayed only once if they're not acknowledged, and then get acked.

# Jira

https://jira.ons.gov.uk/browse/RAS-648