### PR TITLE
Allow livenessProbe and heap memory configuration

### DIFF
--- a/_infra/helm/case/Chart.yaml
+++ b/_infra/helm/case/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 12.0.35
+version: 12.0.36
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 12.0.35
+appVersion: 12.0.36
 

--- a/_infra/helm/case/Chart.yaml
+++ b/_infra/helm/case/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 12.0.37
+version: 12.0.38
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 12.0.37
+appVersion: 12.0.38

--- a/_infra/helm/case/templates/deployment.yaml
+++ b/_infra/helm/case/templates/deployment.yaml
@@ -99,8 +99,8 @@ spec:
             successThreshold: {{ .Values.livenessProbe.successThreshold }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
           env:
-           - name: JAVA_OPTS
-             value: {{ .Values.jvm.java_options }}
+          - name: JAVA_OPTS
+            value: {{ .Values.jvm.java_options }}
           - name: DB_HOST
             {{- if .Values.database.managedPostgres }}
             valueFrom:

--- a/_infra/helm/case/templates/deployment.yaml
+++ b/_infra/helm/case/templates/deployment.yaml
@@ -91,14 +91,16 @@ spec:
             timeoutSeconds: 5
           livenessProbe:
             httpGet:
-              path: /actuator/info
+              path: {{ .Values.livenessProbe.httpGet.path }}
               port: {{ .Values.container.port }}
-            initialDelaySeconds: 300
-            periodSeconds: 20
-            failureThreshold: 5
-            successThreshold: 1
-            timeoutSeconds: 5
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
           env:
+           - name: JAVA_OPTS
+             value: {{ .Values.jvm.java_options }}
           - name: DB_HOST
             {{- if .Values.database.managedPostgres }}
             valueFrom:

--- a/_infra/helm/case/values.yaml
+++ b/_infra/helm/case/values.yaml
@@ -36,6 +36,9 @@ resources:
       memory: "64Mi"
       cpu: "100m"
 
+jvm:
+  java_options: "-Xms512m -Xmx512m"
+
 autoscaling: false
 scaleAt:
   # These are expressed as a percentage of resources.requests, not resources.limits
@@ -46,6 +49,15 @@ maxReplicas: 1
 rollingUpdate:
   maxSurge: 1
   maxUnavailable: 1
+
+livenessProbe:
+  httpGet:
+    path: /actuator/info
+  initialDelaySeconds: 300
+  periodSeconds: 20
+  failureThreshold: 5
+  successThreshold: 1
+  timeoutSeconds: 1800
 
 report:
   cron: "0 * * * * *"


### PR DESCRIPTION
# What and why?

An initial attempt to stop case receiving a sigterm during long running processes (mps)

- allow us to override livenessProbe to stop Kubernetes from killing long running processes
- allow explicit `JAVA_OPTIONS` to allocate more heap